### PR TITLE
feat: add zlib formula (madler/zlib)

### DIFF
--- a/madler/zlib/1.0.0/Zlib_llar.gox
+++ b/madler/zlib/1.0.0/Zlib_llar.gox
@@ -1,0 +1,33 @@
+id "madler/zlib"
+
+fromVer "1.0.0"
+
+onBuild (ctx, proj, out) => {
+	installDir, err := ctx.outputDir()
+	if err != nil {
+		out.addErr err
+		return
+	}
+
+	c := cmake.new(ctx.SourceDir, ctx.SourceDir+"/_build", installDir)
+	c.buildType "Release"
+	c.define "CMAKE_POLICY_VERSION_MINIMUM", "3.5"
+
+	err = c.configure()
+	if err != nil {
+		out.addErr err
+		return
+	}
+	err = c.build()
+	if err != nil {
+		out.addErr err
+		return
+	}
+	err = c.install()
+	if err != nil {
+		out.addErr err
+		return
+	}
+
+	out.setMetadata "-lz"
+}

--- a/madler/zlib/versions.json
+++ b/madler/zlib/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "madler/zlib",
+	"deps": {}
+}


### PR DESCRIPTION
## Summary

- Add the first formula for zlib (`madler/zlib`)
- `versions.json` declares module path with no dependencies
- `Zlib_llar.gox` builds zlib using cmake with `Release` build type and sets metadata to `-lz`

## Files

| File | Description |
|------|-------------|
| `madler/zlib/versions.json` | Module metadata (path, deps) |
| `madler/zlib/1.0.0/Zlib_llar.gox` | Build formula using cmake |
