### PR TITLE
build(zlib): migrate from cmake to autotools build system

### DIFF
--- a/madler/zlib/1.0.0/Zlib_llar.gox
+++ b/madler/zlib/1.0.0/Zlib_llar.gox
@@ -9,21 +9,19 @@ onBuild (ctx, proj, out) => {
 		return
 	}
 
-	c := cmake.new(ctx.SourceDir, ctx.SourceDir+"/_build", installDir)
-	c.buildType "Release"
-	c.define "CMAKE_POLICY_VERSION_MINIMUM", "3.5"
+	a := autotools.new(ctx.SourceDir, ctx.SourceDir+"/_build", installDir)
 
-	err = c.configure()
+	err = a.configure("--static")
 	if err != nil {
 		out.addErr err
 		return
 	}
-	err = c.build()
+	err = a.build()
 	if err != nil {
 		out.addErr err
 		return
 	}
-	err = c.install()
+	err = a.install()
 	if err != nil {
 		out.addErr err
 		return


### PR DESCRIPTION
Replace cmake-based build with autotools for the zlib package. This change simplifies the build configuration by removing cmake-specific policies and using autotools with static library flag instead.

- Replace cmake.new() with autotools.new()
- Remove CMAKE_POLICY_VERSION_MINIMUM definition
- Update configure() call to use --static flag
- Simplify build and install method calls