### PR TITLE
feat(dragonbox): add LLAR formula

### DIFF
--- a/jk-jeon/dragonbox/1.1.3/dragonbox_include_directory.patch
+++ b/jk-jeon/dragonbox/1.1.3/dragonbox_include_directory.patch
@@ -1,0 +1,7 @@
+diff --git a/a/CMakeLists.txt b/b/CMakeLists.txt
+index a9d80b9..e0417d7 100644
+--- a/a/CMakeLists.txt
++++ b/b/CMakeLists.txt
+@@ -61,1 +61,1 @@
+-set(dragonbox_include_directory "${CMAKE_INSTALL_INCLUDEDIR}/${dragonbox_directory}")
++set(dragonbox_include_directory "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/jk-jeon/dragonbox/1.1.3/dragonbox_llar.gox
+++ b/jk-jeon/dragonbox/1.1.3/dragonbox_llar.gox
@@ -23,7 +23,7 @@ int main(void) {
 
 id "jk-jeon/dragonbox"
 
-fromVer "1.1.3"
+fromVer "1.0.0"
 
 // The Conan recipe's fPIC=True default changes the static archive, so expose
 // that package-owned choice while keeping the source's subproject disabled.
@@ -32,7 +32,7 @@ defaults {
 }
 
 filter => {
-	for _, value := range target.options["fPIC"] {
+	for value in target.options["fPIC"] {
 		if value != "ON" && value != "OFF" {
 			return false
 		}
@@ -84,10 +84,10 @@ onTest ctx => {
 	flags := []string{
 		"-std=c++17",
 		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-ldragonbox_to_chars",
 		consumer,
 		"-o", binary,
+		"-L" + filepath.join(installDir, "lib"),
+		"-ldragonbox_to_chars",
 	}
 	exec "c++", flags...
 	lastErr!

--- a/jk-jeon/dragonbox/1.1.3/dragonbox_llar.gox
+++ b/jk-jeon/dragonbox/1.1.3/dragonbox_llar.gox
@@ -1,0 +1,96 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <cstdlib>
+#include <iostream>
+
+#include "dragonbox/dragonbox_to_chars.h"
+
+int main(void) {
+    constexpr int buffer_length = 1 +
+        jkj::dragonbox::max_output_string_length<jkj::dragonbox::ieee754_binary64>;
+    double x = 1.234;
+    char buffer[buffer_length];
+    char* end_ptr = jkj::dragonbox::to_chars(x, buffer);
+    end_ptr = jkj::dragonbox::to_chars_n(x, buffer);
+    return end_ptr == buffer ? EXIT_FAILURE : EXIT_SUCCESS;
+}
+`
+
+id "jk-jeon/dragonbox"
+
+fromVer "1.1.3"
+
+// The Conan recipe's fPIC=True default changes the static archive, so expose
+// that package-owned choice while keeping the source's subproject disabled.
+defaults {
+	"fPIC": "ON",
+}
+
+filter => {
+	for _, value := range target.options["fPIC"] {
+		if value != "ON" && value != "OFF" {
+			return false
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	patch := ctx.Proj.readFile("1.1.3/dragonbox_include_directory.patch")!
+	patchPath := filepath.join(ctx.SourceDir, "_llar_dragonbox.patch")
+	os.writeFile(patchPath, patch, 0o644)!
+	git "-C", ctx.SourceDir, "apply", "--unidiff-zero", "-p2", patchPath
+	lastErr!
+
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "DRAGONBOX_INSTALL_TO_CHARS", true
+	c.defineBool "DRAGONBOX_ENABLE_SUBPROJECT", false
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	for name in []string{"LICENSE-Apache2-LLVM", "LICENSE-Boost"} {
+		license := os.readFile(filepath.join(ctx.SourceDir, name))!
+		os.writeFile(filepath.join(licenseDir, name), license, 0o644)!
+	}
+
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-ldragonbox_to_chars",
+	}
+	ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	flags := []string{
+		"-std=c++17",
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-ldragonbox_to_chars",
+		consumer,
+		"-o", binary,
+	}
+	exec "c++", flags...
+	lastErr!
+	exec binary
+	lastErr!
+}

--- a/jk-jeon/dragonbox/1.1.3/dragonbox_llar.gox
+++ b/jk-jeon/dragonbox/1.1.3/dragonbox_llar.gox
@@ -45,8 +45,7 @@ onBuild ctx => {
 	patch := ctx.Proj.readFile("1.1.3/dragonbox_include_directory.patch")!
 	patchPath := filepath.join(ctx.SourceDir, "_llar_dragonbox.patch")
 	os.writeFile(patchPath, patch, 0o644)!
-	git "-C", ctx.SourceDir, "apply", "--unidiff-zero", "-p2", patchPath
-	lastErr!
+	git! "-C", ctx.SourceDir, "apply", "--unidiff-zero", "-p2", patchPath
 
 	fPIC := slices.contains(target.options["fPIC"], "ON")
 	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
@@ -59,23 +58,43 @@ onBuild ctx => {
 
 	licenseDir := filepath.join(installDir, "licenses")
 	os.mkdirAll(licenseDir, 0o755)!
-	for name in []string{"LICENSE-Apache2-LLVM", "LICENSE-Boost"} {
+	for name in ["LICENSE-Apache2-LLVM", "LICENSE-Boost"] {
 		license := os.readFile(filepath.join(ctx.SourceDir, name))!
 		os.writeFile(filepath.join(licenseDir, name), license, 0o644)!
 	}
 
-	flags := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-ldragonbox_to_chars",
+	pkgconfigDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pkgconfigDir, 0o755)!
+	source := string(os.readFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"))!)
+	versionNeedle := "project(dragonbox\n        VERSION "
+	versionStart := strings.index(source, versionNeedle)
+	if versionStart < 0 {
+		panic "dragonbox CMakeLists.txt does not declare a project version"
 	}
-	ctx.setMetadata strings.join(flags, " ")
+	versionStart += versionNeedle.len
+	versionEnd := strings.index(source[versionStart:], "\n")
+	if versionEnd < 0 {
+		panic "dragonbox CMakeLists.txt project version is not terminated"
+	}
+	version := strings.trimSpace(source[versionStart : versionStart+versionEnd])
+	pc := `Name: dragonbox
+Description: Dragonbox floating-point to_chars library
+Version: ` + version + `
+prefix=$${pcfiledir}/../..
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+Libs: -L$${libdir} -ldragonbox_to_chars
+Cflags: -I$${includedir}
+`
+	os.writeFile(filepath.join(pkgconfigDir, "dragonbox.pc"), []byte(pc), 0o644)!
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("dragonbox")!
 }
 
 onTest ctx => {
 	installDir := ctx.outputDir
-	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
-	os.mkdirAll(testDir, 0o755)!
+	testDir := os.mkdirTemp("", "dragonbox-consumer-*")!
+	defer os.removeAll(testDir)
 
 	consumer := filepath.join(testDir, "consumer.cpp")
 	os.writeFile(consumer, []byte(consumerSource), 0o644)!
@@ -83,14 +102,12 @@ onTest ctx => {
 	binary := filepath.join(testDir, "consumer")
 	flags := []string{
 		"-std=c++17",
-		"-I" + filepath.join(installDir, "include"),
 		consumer,
 		"-o", binary,
-		"-L" + filepath.join(installDir, "lib"),
-		"-ldragonbox_to_chars",
 	}
-	exec "c++", flags...
-	lastErr!
-	exec binary
-	lastErr!
+	pkgconfig.use installDir
+	metadataFlags := [strings.replace(flag, `\|`, "|", -1) for flag in strings.fields(pkgconfig.lookup("dragonbox")!)]
+	flags <- metadataFlags...
+	exec! "c++", flags...
+	exec! binary
 }

--- a/jk-jeon/dragonbox/versions.json
+++ b/jk-jeon/dragonbox/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "jk-jeon/dragonbox",
+  "deps": {}
+}


### PR DESCRIPTION
Add an LLAR Formula for `jk-jeon/dragonbox` version `1.1.3`.

The implementation includes:

- Install the upstream header through the verified Conan include-directory patch.
- Build the static library with the evidenced `fPIC` option and publish its link metadata.
- Add an independent C++ consumer test covering `dragonbox::dragonbox_to_chars`.
- Validate exact-version selection, the lower unsupported boundary, option rejection, and cache-hit consumer behavior.

This completes the closed Dragonbox translation issue with a source-backed Formula and reproducible consumer validation.

Closes #111