### PR TITLE
feat(foxi): add LLAR formula

### DIFF
--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/cmake.patch
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/cmake.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65 +64,0 @@
+-  add_msvc_runtime_flag(foxi_loader)
+@@ -104 +102,0 @@
+-  add_msvc_runtime_flag(foxi_dummy)
+@@ -118 +116 @@
+-  EXPORT ONNXTargets DESTINATION lib)
++  EXPORT ONNXTargets RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)
+@@ -122 +120 @@
+-    EXPORT ONNXTargets DESTINATION lib)
++    EXPORT ONNXTargets RUNTIME DESTINATION bin ARCHIVE DESTINATION lib LIBRARY DESTINATION lib)

--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/consumer.c
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/consumer.c
@@ -1,0 +1,14 @@
+#include <foxi/onnxifi_loader.h>
+
+#include <stdio.h>
+
+int main(void) {
+    struct onnxifi_library onnx;
+    int ret = onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, NULL, &onnx);
+    if (!ret) {
+        printf("Cannot load onnxifi lib\n");
+        return 0;
+    }
+    onnxifi_unload(&onnx);
+    return 0;
+}

--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/consumer.c
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/consumer.c
@@ -2,12 +2,13 @@
 
 #include <stdio.h>
 
-int main(void) {
+int main(int argc, char** argv) {
     struct onnxifi_library onnx;
-    int ret = onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, NULL, &onnx);
+    const char* path = argc > 1 ? argv[1] : NULL;
+    int ret = onnxifi_load(ONNXIFI_LOADER_FLAG_VERSION_1_0, path, &onnx);
     if (!ret) {
-        printf("Cannot load onnxifi lib\n");
-        return 0;
+        fprintf(stderr, "Cannot load onnxifi lib\n");
+        return 1;
     }
     onnxifi_unload(&onnx);
     return 0;

--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/fix-conflicting-types.patch
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/fix-conflicting-types.patch
@@ -1,0 +1,47 @@
+--- a/foxi/onnxifi_dummy.c
++++ b/foxi/onnxifi_dummy.c
+@@ -103,7 +103,9 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI onnxInitGraph(
+     const void* onnxModel,
+     uint32_t weightCount,
+     const onnxTensorDescriptorV1* weightDescriptors,
+-    onnxGraph* graph) {
++    onnxGraph* graph,
++    uint32_t maxSeqLength,
++    void* deferredWeightReader) {
+   if (graph == NULL) {
+     return ONNXIFI_STATUS_INVALID_POINTER;
+   }
+@@ -215,6 +217,8 @@ ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
+ onnxWaitEventFor(onnxEvent event,
+                  uint32_t timeoutMs,
+                  onnxEventState* eventState,
+-                 onnxStatus* eventStatus) {
++                 onnxStatus* eventStatus,
++                 char* message,
++                 size_t* messageLength) {
+   return ONNXIFI_STATUS_SUCCESS;
+ }
+--- a/foxi/onnxifi_wrapper.c
++++ b/foxi/onnxifi_wrapper.c
+@@ -761,7 +761,9 @@ ONNXIFI_PUBLIC onnxStatus ONNXIFI_ABI onnxInitGraph(
+     const void* onnxModel,
+     uint32_t weightsCount,
+     const onnxTensorDescriptorV1* weightDescriptors,
+-    onnxGraph* graph)
++    onnxGraph* graph,
++    uint32_t maxSeqLength,
++    void* deferredWeightReader)
+ {
+   if (graph == NULL) {
+     return ONNXIFI_STATUS_INVALID_POINTER;
+@@ -797,7 +799,9 @@ ONNXIFI_PUBLIC onnxStatus ONNXIFI_ABI onnxInitGraph(
+     onnxModel,
+     weightsCount,
+     weightDescriptors,
+-    &graph_wrapper->graph);
++    &graph_wrapper->graph,
++    maxSeqLength,
++    deferredWeightReader);
+   switch (status) {
+     case ONNXIFI_STATUS_SUCCESS:
+     case ONNXIFI_STATUS_FALLBACK:

--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
@@ -1,7 +1,7 @@
 import (
     "os"
     "path/filepath"
-    "slices"
+    "runtime"
     "strings"
 )
 
@@ -18,14 +18,12 @@ onBuild ctx => {
     patch := ctx.Proj.readFile("bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/fix-conflicting-types.patch")!
     patchPath := filepath.join(ctx.SourceDir, "_llar_fix-conflicting-types.patch")
     os.writeFile(patchPath, patch, 0o644)!
-    patch "-p1", "--batch", "--forward", "-i", patchPath
-    lastErr!
+    patch! "-p1", "--batch", "--forward", "-i", patchPath
 
     cmakePatch := ctx.Proj.readFile("bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/cmake.patch")!
     cmakePatchPath := filepath.join(ctx.SourceDir, "_llar_cmake.patch")
     os.writeFile(cmakePatchPath, cmakePatch, 0o644)!
-    patch "-p1", "--batch", "--forward", "-i", cmakePatchPath
-    lastErr!
+    patch! "-p1", "--batch", "--forward", "-i", cmakePatchPath
 
     c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
     c.define "CMAKE_POLICY_VERSION_MINIMUM", "3.5"
@@ -38,50 +36,62 @@ onBuild ctx => {
     license := os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!
     os.writeFile(filepath.join(licenseDir, "LICENSE"), license, 0o644)!
 
-    // Upstream installs no pkg-config file; match Conan's package_info link contract.
-    flags := []string{
-        "-I" + filepath.join(installDir, "include"),
-        "-L" + filepath.join(installDir, "lib"),
-        "-lfoxi_dummy",
-        "-lfoxi_loader",
+    // Upstream installs no pkg-config file. Build one from its installed
+    // headers, libraries, VERSION_NUMBER, and Conan's verified link contract.
+    version := strings.trimSpace(string(os.readFile(filepath.join(ctx.SourceDir, "VERSION_NUMBER"))!))
+    pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: foxi
+Description: ONNXIFI with Facebook Extension
+Version: ` + version + `
+Libs: -L$${libdir} -lfoxi_dummy -lfoxi_loader`
+    osName := runtime.GOOS
+    osValues := target.require["os"]
+    if osValues.len > 0 {
+        osName = osValues[0]
     }
-    if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
-        flags <- "-ldl"
+    if osName == "linux" || osName == "freebsd" {
+        pc += " -ldl"
     }
-    ctx.setMetadata strings.join(flags, " ")
+    pc += `
+Cflags: -I$${includedir}
+`
+    pkgconfigDir := filepath.join(installDir, "lib", "pkgconfig")
+    os.mkdirAll(pkgconfigDir, 0o755)!
+    os.writeFile(filepath.join(pkgconfigDir, "foxi.pc"), []byte(pc), 0o644)!
+
+    pkgconfig.use installDir
+    ctx.setMetadata pkgconfig.lookup("foxi")!
 }
 
 onTest ctx => {
     installDir := ctx.outputDir
-    testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
-    os.mkdirAll(testDir, 0o755)!
+    testDir := os.mkdirTemp("", "foxi-consumer-*")!
+    defer os.removeAll(testDir)
 
     source := ctx.Proj.readFile("bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/consumer.c")!
     sourcePath := filepath.join(testDir, "consumer.c")
     os.writeFile(sourcePath, source, 0o644)!
 
-    flags := []string{
-        "-I" + filepath.join(installDir, "include"),
-        "-L" + filepath.join(installDir, "lib"),
-        "-lfoxi_dummy",
-        "-lfoxi_loader",
-    }
-    if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
-        flags <- "-ldl"
-    }
     binary := filepath.join(testDir, "consumer")
-    args := []string{sourcePath, "-o", binary}
-    args <- flags...
-    cc args...
-    lastErr!
+    pkgconfig.use installDir
+    flagsFile := filepath.join(testDir, "foxi.flags")
+    os.writeFile(flagsFile, []byte(pkgconfig.lookup("foxi")!), 0o644)!
+    cc! sourcePath, "-o", binary, "@"+flagsFile
 
+    osName := runtime.GOOS
+    osValues := target.require["os"]
+    if osValues.len > 0 {
+        osName = osValues[0]
+    }
     os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
     os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
-    _, err := os.stat(filepath.join(installDir, "lib", "libfoxi.dylib"))
     libraryName := "libfoxi.so"
-    if err == nil {
+    if osName == "darwin" {
         libraryName = "libfoxi.dylib"
     }
-    exec binary, filepath.join(installDir, "lib", libraryName)
-    lastErr!
+    exec! binary, filepath.join(installDir, "lib", libraryName)
 }

--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
@@ -1,0 +1,76 @@
+import (
+    "os"
+    "path/filepath"
+    "strings"
+)
+
+// Conan Center cci.20210217 pins houseroad/foxi to this commit. The upstream
+// repository has no release tags, so this commit is the only fetchable source
+// ref for the selected recipe snapshot.
+id "houseroad/foxi"
+
+fromVer "bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5"
+
+onBuild ctx => {
+    installDir := ctx.outputDir
+
+    patch := ctx.Proj.readFile("bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/fix-conflicting-types.patch")!
+    patchPath := filepath.join(ctx.SourceDir, "_llar_fix-conflicting-types.patch")
+    os.writeFile(patchPath, patch, 0o644)!
+    patch "-p1", "--batch", "--forward", "-i", patchPath
+    lastErr!
+
+    cmakePatch := ctx.Proj.readFile("bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/cmake.patch")!
+    cmakePatchPath := filepath.join(ctx.SourceDir, "_llar_cmake.patch")
+    os.writeFile(cmakePatchPath, cmakePatch, 0o644)!
+    patch "-p1", "--batch", "--forward", "-i", cmakePatchPath
+    lastErr!
+
+    c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+    c.define "CMAKE_POLICY_VERSION_MINIMUM", "3.5"
+    c.configure
+    c.build
+    c.install
+
+    licenseDir := filepath.join(installDir, "licenses")
+    os.mkdirAll(licenseDir, 0o755)!
+    license := os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!
+    os.writeFile(filepath.join(licenseDir, "LICENSE"), license, 0o644)!
+
+    flags := []string{
+        "-I" + filepath.join(installDir, "include"),
+        "-L" + filepath.join(installDir, "lib"),
+        "-lfoxi_dummy",
+        "-lfoxi_loader",
+        "-ldl",
+    }
+    ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+    installDir := ctx.outputDir
+    testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+    os.mkdirAll(testDir, 0o755)!
+
+    source := ctx.Proj.readFile("bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/consumer.c")!
+    sourcePath := filepath.join(testDir, "consumer.c")
+    os.writeFile(sourcePath, source, 0o644)!
+
+    flags := []string{
+        "-I" + filepath.join(installDir, "include"),
+        "-L" + filepath.join(installDir, "lib"),
+        "-lfoxi_dummy",
+        "-lfoxi_loader",
+        "-ldl",
+    }
+    binary := filepath.join(testDir, "consumer")
+    args := []string{sourcePath, "-o", binary}
+    args = append(args, flags...)
+    exec "cc", args...
+    lastErr!
+
+    os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+    os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+    exec binary
+    lastErr!
+}

--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
@@ -1,6 +1,7 @@
 import (
     "os"
     "path/filepath"
+    "slices"
     "strings"
 )
 
@@ -37,12 +38,15 @@ onBuild ctx => {
     license := os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!
     os.writeFile(filepath.join(licenseDir, "LICENSE"), license, 0o644)!
 
+    // Upstream installs no pkg-config file; match Conan's package_info link contract.
     flags := []string{
         "-I" + filepath.join(installDir, "include"),
         "-L" + filepath.join(installDir, "lib"),
         "-lfoxi_dummy",
         "-lfoxi_loader",
-        "-ldl",
+    }
+    if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
+        flags <- "-ldl"
     }
     ctx.setMetadata strings.join(flags, " ")
 }
@@ -61,7 +65,9 @@ onTest ctx => {
         "-L" + filepath.join(installDir, "lib"),
         "-lfoxi_dummy",
         "-lfoxi_loader",
-        "-ldl",
+    }
+    if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
+        flags <- "-ldl"
     }
     binary := filepath.join(testDir, "consumer")
     args := []string{sourcePath, "-o", binary}

--- a/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
+++ b/houseroad/foxi/bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5/foxi_llar.gox
@@ -65,12 +65,17 @@ onTest ctx => {
     }
     binary := filepath.join(testDir, "consumer")
     args := []string{sourcePath, "-o", binary}
-    args = append(args, flags...)
-    exec "cc", args...
+    args <- flags...
+    cc args...
     lastErr!
 
     os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
     os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
-    exec binary
+    _, err := os.stat(filepath.join(installDir, "lib", "libfoxi.dylib"))
+    libraryName := "libfoxi.so"
+    if err == nil {
+        libraryName = "libfoxi.dylib"
+    }
+    exec binary, filepath.join(installDir, "lib", libraryName)
     lastErr!
 }

--- a/houseroad/foxi/versions.json
+++ b/houseroad/foxi/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "houseroad/foxi",
+  "deps": {}
+}


### PR DESCRIPTION
Add an LLAR Formula for `houseroad/foxi` at Conan source commit `bd6feb6d0d3fc903df42b4feb82a602a5fcb1fd5`.

The implementation includes:

- Carry the verified Conan CMake patch and install the foxi headers and libraries into the LLAR output.
- Preserve the source-backed static, shared, and module targets without adding unverified dependencies.
- Publish installed link metadata and compile an independent C consumer against the result.
- Validate fresh and cache-hit builds with the exact source commit on Darwin arm64.

The upstream repository has no release tags, so the Formula uses the immutable Conan source commit explicitly and avoids inventing a version comparator.

Closes #110