### PR TITLE
feat(chaiscript): add LLAR formula

### DIFF
--- a/ChaiScript/ChaiScript/chaiscript_cmp.gox
+++ b/ChaiScript/ChaiScript/chaiscript_cmp.gox
@@ -1,0 +1,26 @@
+import "strings"
+
+// Stable releases use v-prefixed semantic versions, while the repository
+// also keeps Release-* aliases and two named snapshots. The snapshots are
+// mapped to their source-tree release lines so every visible tag is accepted
+// without letting the WebAssembly-only snapshot become the default native
+// build.
+func normalize(version string) string {
+	if strings.hasPrefix(version, "Release-") {
+		return "v" + strings.trimPrefix(version, "Release-")
+	}
+	if version == "Test_Release" {
+		return "v5.7.2"
+	}
+	if version == "wasm-latest" {
+		// wasm-latest is a v7.0.0 source snapshot, but it is not a native
+		// release; keep it below v6.1.0 so native default selection remains
+		// usable while the tag stays in the comparator's domain.
+		return "v6.1.0-0"
+	}
+	return version
+}
+
+compareVer (a, b) => {
+	return semver.Compare(normalize(a.Version), normalize(b.Version))
+}

--- a/ChaiScript/ChaiScript/v5.0.0/chaiscript_llar.gox
+++ b/ChaiScript/ChaiScript/v5.0.0/chaiscript_llar.gox
@@ -1,0 +1,91 @@
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const consumerSource = `#include <chaiscript/chaiscript.hpp>
+#include <iostream>
+#include <cassert>
+
+double chai_add(double i, double j)
+{
+  return i + j;
+}
+
+int main()
+{
+  chaiscript::ChaiScript chai({CHAI_MODULE_PATH});
+  chai.add(chaiscript::fun(&chai_add), "add");
+  const auto answer = chai.eval<double>("add(38.8, 3.2);");
+  assert(static_cast<int>(answer) == 42);
+  std::cout << "The answer is: " << answer << '\n';
+}
+`
+
+id "ChaiScript/ChaiScript"
+
+fromVer "v5.0.0"
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	// The supported release line declares CMake 2.8; current CMake rejects
+	// that policy floor unless the minimum policy version is made explicit.
+	c.define "CMAKE_POLICY_VERSION_MINIMUM", "3.5"
+	c.defineBool "BUILD_TESTING", false
+	c.defineBool "BUILD_SAMPLES", false
+	c.defineBool "BUILD_MODULES", true
+	c.defineBool "MULTITHREAD_SUPPORT_ENABLED", true
+	c.configure
+	c.build
+	c.install
+
+	// v5.0.0-v5.3.0 omit the standard-library module from install; newer
+	// releases install it under a versioned name. Copy the built module by its
+	// actual name so the runtime loader can find either contract.
+	stdlibPath := filepath.glob(filepath.join(ctx.SourceDir, "_build", "libchaiscript_stdlib*"))![0]
+	stdlib := os.readFile(stdlibPath)!
+	os.writeFile(filepath.join(installDir, "lib", "chaiscript", filepath.base(stdlibPath)), stdlib, 0o755)!
+
+	// Keep the license published by the Conan package.
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	license := os.readFile(filepath.join(ctx.SourceDir, "license.txt"))!
+	os.writeFile(filepath.join(licenseDir, "license.txt"), license, 0o644)!
+
+	// The upstream file embeds the build output path. Make it relocatable
+	// before using the installed pkg-config contract for Formula metadata.
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", "chaiscript.pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix="+installDir, `prefix=$${pcfiledir}/../..`, 1)
+	pc = strings.replace(pc, "Libs: ", "Libs: -ldl -pthread", 1)
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("chaiscript")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.cpp")
+	modulePath := "\"" + filepath.join(installDir, "lib", "chaiscript") + "/\""
+	source := strings.replace(consumerSource, "CHAI_MODULE_PATH", modulePath, 1)
+	os.writeFile(consumer, []byte(source), 0o644)!
+
+	// Resolve the complete installed cflags-and-libs query so this test checks
+	// the same metadata that downstream consumers receive, including on cache
+	// hits where onBuild is skipped.
+	pkgconfig.use installDir
+	flags := pkgconfig.lookup("chaiscript")!
+	flagsFile := filepath.join(testDir, "chaiscript.flags")
+	os.writeFile(flagsFile, []byte(flags), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	exec! "c++", "-std=c++17", consumer, "-o", binary, "@"+flagsFile
+	exec! binary
+}

--- a/ChaiScript/ChaiScript/versions.json
+++ b/ChaiScript/ChaiScript/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "ChaiScript/ChaiScript",
+  "deps": {}
+}


### PR DESCRIPTION
Add an LLAR Formula for `ChaiScript/ChaiScript` from `v5.0.0` through `v6.1.0`.

The implementation includes:

- Set `fromVer` at the first no-Boost release after verifying the older Boost-dependent CMake contract.
- Add an exhaustive comparator for the repository aliases and named snapshot tags, including `wasm-latest`.
- Build and install ChaiScript modules, preserve the license, and make the installed pkg-config prefix relocatable.
- Use the complete `pkgconfig.lookup("chaiscript")` metadata in both the Formula and independent C++ consumer test.
- Validate v5.0.0, v6.1.0, default selection, fresh builds, and cache-hit consumers on Darwin arm64.

This completes the closed ChaiScript translation with explicit version ordering and relocatable consumer metadata.

Closes #108