### PR TITLE
feat(bzip3): add LLAR formula

### DIFF
--- a/iczelia/bzip3/1.3.2/bzip3_llar.gox
+++ b/iczelia/bzip3/1.3.2/bzip3_llar.gox
@@ -2,6 +2,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 )
 
 id "iczelia/bzip3"
@@ -47,6 +48,15 @@ onBuild ctx => {
 	c.build
 	c.install
 
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", "bzip3.pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix=" + installDir, "prefix=$${pcfiledir}/../..", 1)
+	pc = strings.replace(pc, "exec_prefix=" + installDir, "exec_prefix=$${prefix}", 1)
+	pc = strings.replace(pc, "bindir=" + filepath.join(installDir, "bin"), "bindir=$${exec_prefix}/bin", 1)
+	pc = strings.replace(pc, "libdir=" + filepath.join(installDir, "lib"), "libdir=$${exec_prefix}/lib", 1)
+	pc = strings.replace(pc, "includedir=" + filepath.join(installDir, "include"), "includedir=$${prefix}/include", 1)
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
 	pkgconfig.use installDir
 	ctx.setMetadata pkgconfig.lookup("bzip3")!
 }
@@ -88,8 +98,5 @@ add_executable(consumer consumer.c)
 	tc.define "CMAKE_BUILD_RPATH", filepath.join(installDir, "lib")
 	tc.configure
 	tc.build
-	exec binary
-	if lastErr != nil {
-		panic lastErr
-	}
+	exec! binary
 }

--- a/iczelia/bzip3/1.3.2/bzip3_llar.gox
+++ b/iczelia/bzip3/1.3.2/bzip3_llar.gox
@@ -1,0 +1,95 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+id "iczelia/bzip3"
+
+// Upstream's native CMake project and installable pkg-config metadata start
+// at 1.3.2; tags before it only provide Makefile or Autotools entrypoints.
+fromVer "1.3.2"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"with_thread": "ON",
+	"with_util": "OFF",
+}
+
+filter => {
+	for key in []string{"shared", "fPIC", "with_thread", "with_util"} {
+		for value in target.options[key] {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	withThread := slices.contains(target.options["with_thread"], "ON")
+	withUtil := slices.contains(target.options["with_util"], "ON")
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "BZIP3_ENABLE_PTHREAD", withThread
+	// 1.3.2 defaults this upstream optimization to ON, while the Conan
+	// project wrapper leaves it disabled for reproducible, portable builds.
+	c.defineBool "BZIP3_ENABLE_ARCH_NATIVE", false
+	c.defineBool "BZIP3_BUILD_APPS", withUtil
+	c.configure
+	c.build
+	c.install
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("bzip3")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	testSource := filepath.join(testDir, "consumer.c")
+	testBuild := filepath.join(testDir, "_build")
+	binary := filepath.join(testBuild, "consumer")
+
+	os.mkdirAll(testDir, 0755)!
+	os.writeFile(testSource, []byte(`#include "libbz3.h"
+
+int main(void) {
+    struct bz3_state *state = bz3_new(8 * 1024 * 1024);
+    if (state == 0) {
+        return 1;
+    }
+    if (bz3_version() == 0) {
+        bz3_free(state);
+        return 1;
+    }
+    bz3_free(state);
+    return 0;
+}
+`), 0644)!
+
+	pkgconfig.use installDir
+	metadata := pkgconfig.lookup("bzip3")!
+	os.writeFile(filepath.join(testDir, "CMakeLists.txt"), []byte(`cmake_minimum_required(VERSION 3.15)
+project(bzip3_consumer LANGUAGES C)
+add_executable(consumer consumer.c)
+`), 0644)!
+
+	tc := cmake.new(testDir, testBuild, "")
+	tc.use installDir
+	tc.define "CMAKE_C_FLAGS", metadata
+	tc.define "CMAKE_BUILD_RPATH", filepath.join(installDir, "lib")
+	tc.configure
+	tc.build
+	exec binary
+	if lastErr != nil {
+		panic lastErr
+	}
+}

--- a/iczelia/bzip3/bzip3_cmp.gox
+++ b/iczelia/bzip3/bzip3_cmp.gox
@@ -1,0 +1,14 @@
+// Keep the upstream test corpus below every numbered release so an unpinned
+// LLAR selection resolves to the latest buildable release instead of corpus.
+compareVer (a, b) => {
+	if a.Version == "corpus" {
+		if b.Version == "corpus" {
+			return 0
+		}
+		return -1
+	}
+	if b.Version == "corpus" {
+		return 1
+	}
+	return gnu.compare(a.Version, b.Version)
+}

--- a/iczelia/bzip3/versions.json
+++ b/iczelia/bzip3/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "iczelia/bzip3",
+	"deps": {}
+}


### PR DESCRIPTION
## Summary

- add the `iczelia/bzip3` LLAR Formula from upstream `1.3.2`
- map Conan's `shared`, `fPIC`, `with_thread`, and `with_util` build choices
- install and consume the upstream `bzip3.pc` metadata through the complete pkg-config lookup
- verify the installed C API with an independent consumer build
- order upstream's non-release `corpus` tag below numbered releases so an unpinned build selects `1.5.3`

Closes #106

## Validation

- `llar test --verbose ./iczelia/bzip3 --os darwin --arch arm64` (unpinned latest selects `1.5.3`)
- `llar test --verbose ./iczelia/bzip3@1.3.2 --os darwin --arch arm64`
- `llar test --verbose ./iczelia/bzip3@1.4.0 --os darwin --arch arm64`
- `llar test --verbose ./iczelia/bzip3@1.5.3 --os darwin --arch arm64` (fresh build)
- repeated `1.5.3` selection to exercise the cache-hit consumer path
- `1.3.1` and explicit `corpus` are rejected below the `1.3.2` Formula boundary
- invalid boolean option selection is rejected by the Formula filter
