### PR TITLE
feat(drmp3): add LLAR formula

### DIFF
--- a/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/CMakeLists.txt
+++ b/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.15)
+project(dr_mp3 LANGUAGES C)
+
+include(GNUInstallDirs)
+
+option(NO_SIMD "Build with define DR_MP3_NO_SIMD" OFF)
+option(NO_STDIO "Build with define DR_MP3_NO_STDIO" OFF)
+
+add_library(${CMAKE_PROJECT_NAME} dr_mp3.c)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${DRMP3_SRC_DIR})
+
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+    PUBLIC_HEADER ${DRMP3_SRC_DIR}/dr_mp3.h
+    C_STANDARD 99
+)
+
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDRMP3_DLL)
+endif()
+if(NO_SIMD)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_SIMD)
+endif()
+if(NO_STDIO)
+    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC -DDR_MP3_NO_STDIO)
+endif()
+
+install(TARGETS ${CMAKE_PROJECT_NAME}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/dr_mp3.c
+++ b/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/dr_mp3.c
@@ -1,0 +1,3 @@
+#define DR_MP3_IMPLEMENTATION
+
+#include "dr_mp3.h"

--- a/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/drmp3_llar.gox
+++ b/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/drmp3_llar.gox
@@ -29,8 +29,8 @@ defaults {
 }
 
 filter => {
-	for _, name := range []string{"shared", "fPIC", "no_simd", "no_stdio"} {
-		for _, value := range target.options[name] {
+	for name in []string{"shared", "fPIC", "no_simd", "no_stdio"} {
+		for value in target.options[name] {
 			if value != "ON" && value != "OFF" {
 				return false
 			}
@@ -127,7 +127,7 @@ onTest ctx => {
 	os.writeFile(flagsFile, []byte(flags), 0o644)!
 
 	binary := filepath.join(testDir, "consumer")
-	exec "cc", "-std=c99", "@"+flagsFile, consumer, "-o", binary
+	cc "-std=c99", "@"+flagsFile, consumer, "-o", binary
 	lastErr!
 
 	os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!

--- a/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/drmp3_llar.gox
+++ b/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/drmp3_llar.gox
@@ -127,11 +127,9 @@ onTest ctx => {
 	os.writeFile(flagsFile, []byte(flags), 0o644)!
 
 	binary := filepath.join(testDir, "consumer")
-	cc "-std=c99", "@"+flagsFile, consumer, "-o", binary
-	lastErr!
+	cc! "-std=c99", "@"+flagsFile, consumer, "-o", binary
 
 	os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 	os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
-	exec binary
-	lastErr!
+	exec! binary
 }

--- a/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/drmp3_llar.gox
+++ b/mackron/dr_libs/9497270f581f43e6b795ce5d98d8764861fb6a50/drmp3_llar.gox
@@ -1,0 +1,137 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <stdio.h>
+#include "dr_mp3.h"
+
+int main(void) {
+    const char *version = drmp3_version_string();
+    puts(version);
+    return version == NULL;
+}
+`
+
+id "mackron/dr_libs"
+
+// The Conan recipe serves 0.6.32, 0.6.34, and 0.6.38 from one build recipe.
+// Their exported CMake contract and installed dr_mp3.h interface are the same.
+fromVer "9497270f581f43e6b795ce5d98d8764861fb6a50"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"no_simd": "OFF",
+	"no_stdio": "OFF",
+}
+
+filter => {
+	for _, name := range []string{"shared", "fPIC", "no_simd", "no_stdio"} {
+		for _, value := range target.options[name] {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	// CCI exports these two files because dr_libs is a single-header library.
+	cmakeLists := ctx.Proj.readFile("9497270f581f43e6b795ce5d98d8764861fb6a50/CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+	implementation := ctx.Proj.readFile("9497270f581f43e6b795ce5d98d8764861fb6a50/dr_mp3.c")!
+	os.writeFile(filepath.join(ctx.SourceDir, "dr_mp3.c"), implementation, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	noSimd := slices.contains(target.options["no_simd"], "ON")
+	noStdio := slices.contains(target.options["no_stdio"], "ON")
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "DRMP3_SRC_DIR", ctx.SourceDir
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "NO_SIMD", noSimd
+	c.defineBool "NO_STDIO", noStdio
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	license := os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), license, 0o644)!
+
+	// Keep the package metadata relocatable and synchronized with every
+	// output-changing option exposed by the Conan recipe.
+	header := string(os.readFile(filepath.join(ctx.SourceDir, "dr_mp3.h"))!)
+	versionParts := map[string]string{}
+	for line in strings.split(header, "\n") {
+		fields := strings.fields(line)
+		if fields.len == 3 && fields[0] == "#define" {
+			versionParts[fields[1]] = fields[2]
+		}
+	}
+	version := strings.join([]string{
+		versionParts["DRMP3_VERSION_MAJOR"],
+		versionParts["DRMP3_VERSION_MINOR"],
+		versionParts["DRMP3_VERSION_REVISION"],
+	}, ".")
+
+	cflags := "-I$${includedir}"
+	if shared {
+		cflags += " -DDRMP3_DLL"
+	}
+	if noSimd {
+		cflags += " -DDR_MP3_NO_SIMD"
+	}
+	if noStdio {
+		cflags += " -DDR_MP3_NO_STDIO"
+	}
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: drmp3
+Description: MP3 audio decoder
+Version: ` + version + `
+Libs: -L$${libdir} -ldr_mp3
+Cflags: ` + cflags + `
+`
+	os.writeFile(filepath.join(pcDir, "drmp3.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("drmp3")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.c")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flags := pkgconfig.lookup("drmp3")!
+	flagsFile := filepath.join(testDir, "drmp3.flags")
+	os.writeFile(flagsFile, []byte(flags), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	exec "cc", "-std=c99", "@"+flagsFile, consumer, "-o", binary
+	lastErr!
+
+	os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	exec binary
+	lastErr!
+}

--- a/mackron/dr_libs/drmp3_cmp.gox
+++ b/mackron/dr_libs/drmp3_cmp.gox
@@ -1,0 +1,32 @@
+import "strings"
+
+// dr_libs publishes flac-, mp3-, and wav-prefixed tags in one repository.
+// Conan also selects three untagged dr_mp3 release commits. The default GNU
+// comparator orders those commit hashes by spelling, not by their release
+// versions (for example, 0.6.38's 01d23... sorts before 0.6.32's 949727...).
+// Map every visible tag and Conan ref into a distinct semver namespace so the
+// mp3 release line is ordered chronologically and remains the latest line.
+func normalize(version string) string {
+	switch version {
+	case "9497270f581f43e6b795ce5d98d8764861fb6a50":
+		return "v3.6.32"
+	case "dd762b861ecadf5ddd5fb03e9ca1db6707b54fbb":
+		return "v3.6.34"
+	case "01d23df76776faccee3bc456f685900dcc273b4c":
+		return "v3.6.38"
+	}
+	if strings.hasPrefix(version, "flac-") {
+		return "v1." + strings.trimPrefix(strings.trimPrefix(version, "flac-"), "0.")
+	}
+	if strings.hasPrefix(version, "wav-") {
+		return "v2." + strings.trimPrefix(strings.trimPrefix(version, "wav-"), "0.")
+	}
+	if strings.hasPrefix(version, "mp3-") {
+		return "v3." + strings.trimPrefix(strings.trimPrefix(version, "mp3-"), "0.")
+	}
+	return version
+}
+
+compareVer (a, b) => {
+	return semver.Compare(normalize(a.Version), normalize(b.Version))
+}

--- a/mackron/dr_libs/versions.json
+++ b/mackron/dr_libs/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "mackron/dr_libs",
+	"deps": {}
+}


### PR DESCRIPTION
## Summary

- add the `mackron/dr_libs` LLAR Formula from the Conan drmp3 recipe
- support Conan refs 0.6.32, 0.6.34, and 0.6.38 plus current mp3 tags with verified comparator ordering
- publish relocatable `drmp3.pc` metadata and validate an installed C consumer

## Validation

- `llar test -v ./mackron/dr_libs@9497270f581f43e6b795ce5d98d8764861fb6a50`
- cache-hit rerun of the same command
- `llar test -v ./mackron/dr_libs@01d23df76776faccee3bc456f685900dcc273b4c`
- `llar test -v ./mackron/dr_libs@mp3-0.7.3`
- installed `pkg-config --cflags --libs drmp3` lookup