### PR TITLE
feat(farmhash): add LLAR formula

### DIFF
--- a/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/CMakeLists.txt
+++ b/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.15)
+project(farmhash LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+if(NOT FARMHASH_NO_BUILTIN_EXPECT)
+    # Transcribed from farmhash/src/Makefile.am
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles(
+        "int main(int argc, char* argv[]) { return (int)__builtin_expect(0, 0); }"
+        FARMHASH_HAS_BUILTIN_EXPECT
+    )
+endif()
+
+add_library(farmhash "${FARMHASH_SRC_DIR}/src/farmhash.cc" )
+target_include_directories(farmhash PRIVATE "${FARMHASH_SRC_DIR}/src")
+
+if(NOT FARMHASH_HAS_BUILTIN_EXPECT)
+    target_compile_definitions(farmhash PUBLIC FARMHASH_NO_BUILTIN_EXPECT)
+endif()
+
+set_target_properties(farmhash
+    PROPERTIES
+        PUBLIC_HEADER "${FARMHASH_SRC_DIR}/src/farmhash.h"
+        WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+install(TARGETS farmhash
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/CMakeLists.txt
+++ b/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 3.15)
-project(farmhash LANGUAGES CXX)
+project(farmhash VERSION 1.1.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
+
+# FarmHash's Autotools install layout uses lib/, which is also the LLAR
+# pkg-config search path.
+set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "" FORCE)
 
 if(NOT FARMHASH_NO_BUILTIN_EXPECT)
     # Transcribed from farmhash/src/Makefile.am
@@ -31,3 +35,18 @@ install(TARGETS farmhash
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+set(FARMHASH_PC "${CMAKE_CURRENT_BINARY_DIR}/farmhash.pc")
+file(WRITE "${FARMHASH_PC}"
+"prefix=\${pcfiledir}/../..\n"
+"exec_prefix=\${prefix}\n"
+"libdir=\${prefix}/${CMAKE_INSTALL_LIBDIR}\n"
+"includedir=\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}\n"
+"\n"
+"Name: farmhash\n"
+"Description: FarmHash non-cryptographic hash functions\n"
+"Version: ${PROJECT_VERSION}\n"
+"Libs: -L\${libdir} -lfarmhash\n"
+"Cflags: -I\${includedir}\n"
+)
+install(FILES "${FARMHASH_PC}" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/farmhash_llar.gox
+++ b/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/farmhash_llar.gox
@@ -30,6 +30,8 @@ fromVer "0d859a811870d10f53a594927d0d0b97573ad06d"
 defaults {
 	"shared": "OFF",
 	"fPIC": "ON",
+	// OFF lets CMake probe for __builtin_expect; ON always defines the
+	// public FARMHASH_NO_BUILTIN_EXPECT consumer macro.
 	"no_builtin_expect": "OFF",
 }
 
@@ -70,12 +72,9 @@ onBuild ctx => {
 	os.mkdirAll(licenseDir, 0o755)!
 	os.writeFile(filepath.join(licenseDir, "COPYING"), os.readFile(filepath.join(ctx.SourceDir, "COPYING"))!, 0o644)!
 
-	flags := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-lfarmhash",
-	}
-	ctx.setMetadata strings.join(flags, " ")
+	pkgconfig.use installDir
+	metadata := pkgconfig.lookup("farmhash")!
+	ctx.setMetadata metadata
 }
 
 onTest ctx => {
@@ -87,19 +86,26 @@ onTest ctx => {
 	os.writeFile(consumer, []byte(consumerSource), 0o644)!
 
 	binary := filepath.join(testDir, "consumer")
-	flags := []string{
-		"-I" + filepath.join(installDir, "include"),
-		consumer,
-		"-L" + filepath.join(installDir, "lib"),
-		"-lfarmhash",
-		"-o", binary,
-	}
-	exec "c++", flags...
+
+	pkgconfig.use installDir
+	flags := strings.fields(pkgconfig.lookup("farmhash")!)
+	args := []string{consumer, "-o", binary}
+	args = append(args, flags...)
+	exec "c++", args...
 	lastErr!
 
 	if slices.contains(target.options["shared"], "ON") {
-		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
-		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		libDir := filepath.join(installDir, "lib")
+		ldPath := libDir
+		if current := os.getenv("LD_LIBRARY_PATH"); current != "" {
+			ldPath += ":" + current
+		}
+		dyldPath := libDir
+		if current := os.getenv("DYLD_LIBRARY_PATH"); current != "" {
+			dyldPath += ":" + current
+		}
+		exec! {"LD_LIBRARY_PATH": ldPath, "DYLD_LIBRARY_PATH": dyldPath}, binary
+		return
 	}
 	exec binary
 	lastErr!

--- a/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/farmhash_llar.gox
+++ b/google/farmhash/0d859a811870d10f53a594927d0d0b97573ad06d/farmhash_llar.gox
@@ -1,0 +1,106 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <farmhash.h>
+
+#include <iostream>
+#include <string>
+
+int main() {
+    std::string aString = "Conan";
+    uint32_t hashResult;
+
+    hashResult = util::Hash32(aString);
+
+    std::cout << "Input string: " << aString << std::endl;
+    std::cout << "Generated hash: " << hashResult << std::endl;
+
+    return 0;
+}
+`
+
+id "google/farmhash"
+
+fromVer "0d859a811870d10f53a594927d0d0b97573ad06d"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"no_builtin_expect": "OFF",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" && name != "no_builtin_expect" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	cmakeLists := ctx.Proj.readFile("0d859a811870d10f53a594927d0d0b97573ad06d/CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	noBuiltinExpect := slices.contains(target.options["no_builtin_expect"], "ON")
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "FARMHASH_SRC_DIR", ctx.SourceDir
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "FARMHASH_NO_BUILTIN_EXPECT", noBuiltinExpect
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "COPYING"), os.readFile(filepath.join(ctx.SourceDir, "COPYING"))!, 0o644)!
+
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lfarmhash",
+	}
+	ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		consumer,
+		"-L" + filepath.join(installDir, "lib"),
+		"-lfarmhash",
+		"-o", binary,
+	}
+	exec "c++", flags...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary
+	lastErr!
+}

--- a/google/farmhash/versions.json
+++ b/google/farmhash/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "google/farmhash",
+	"deps": {}
+}


### PR DESCRIPTION
Closes #100.

Adds the `google/farmhash` Formula for source ref `0d859a811870d10f53a594927d0d0b97573ad06d`, including the Conan-exported CMake entrypoint, shared/fPIC/no_builtin_expect options, installed license, consumer metadata, and an independent C++ consumer test.

Validated locally with LLAR `b4164750da04f08c179965eb2f7b5087b1fc260c`:

- `/tmp/llar-b416 test -v ./google/farmhash@0d859a811870d10f53a594927d0d0b97573ad06d --os linux --arch amd64`
- Repeated the same command to exercise cache-hit `onTest`.
