### PR TITLE
feat(log.c): add LLAR formula

### DIFF
--- a/madler/zlib/1.0.0/Zlib_llar.gox
+++ b/madler/zlib/1.0.0/Zlib_llar.gox
@@ -2,30 +2,13 @@ id "madler/zlib"
 
 fromVer "1.0.0"
 
-onBuild (ctx, proj, out) => {
-	installDir, err := ctx.outputDir()
-	if err != nil {
-		out.addErr err
-		return
-	}
+onBuild ctx => {
+	installDir := ctx.outputDir
 
 	a := autotools.new(ctx.SourceDir, ctx.SourceDir+"/_build", installDir)
+	a.configure "--static"
+	a.build
+	a.install
 
-	err = a.configure("--static")
-	if err != nil {
-		out.addErr err
-		return
-	}
-	err = a.build()
-	if err != nil {
-		out.addErr err
-		return
-	}
-	err = a.install()
-	if err != nil {
-		out.addErr err
-		return
-	}
-
-	out.setMetadata "-lz"
+	ctx.setMetadata "-lz"
 }

--- a/madler/zlib/1.0.0/Zlib_llar.gox
+++ b/madler/zlib/1.0.0/Zlib_llar.gox
@@ -2,13 +2,30 @@ id "madler/zlib"
 
 fromVer "1.0.0"
 
-onBuild ctx => {
-	installDir := ctx.outputDir
+onBuild (ctx, proj, out) => {
+	installDir, err := ctx.outputDir()
+	if err != nil {
+		out.addErr err
+		return
+	}
 
 	a := autotools.new(ctx.SourceDir, ctx.SourceDir+"/_build", installDir)
-	a.configure "--static"
-	a.build
-	a.install
 
-	ctx.setMetadata "-lz"
+	err = a.configure("--static")
+	if err != nil {
+		out.addErr err
+		return
+	}
+	err = a.build()
+	if err != nil {
+		out.addErr err
+		return
+	}
+	err = a.install()
+	if err != nil {
+		out.addErr err
+		return
+	}
+
+	out.setMetadata "-lz"
 }

--- a/rxi/log.c/f9ea34994bd58ed342d2245cd4110bb5c6790153/log_llar.gox
+++ b/rxi/log.c/f9ea34994bd58ed342d2245cd4110bb5c6790153/log_llar.gox
@@ -2,7 +2,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 )
 
 var cmakeLists = `cmake_minimum_required(VERSION 3.8)
@@ -84,12 +83,22 @@ onBuild ctx => {
 	os.mkdirAll(licenseDir, 0o755)!
 	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
 
-	flags := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-llog.c",
-	}
-	ctx.setMetadata strings.join(flags, " ")
+	pkgconfigDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pkgconfigDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+includedir=$${prefix}/include
+libdir=$${prefix}/lib
+
+Name: log.c
+Description: A simple logging library implemented in C99
+Version: f9ea34994bd58ed342d2245cd4110bb5c6790153
+Cflags: -I$${includedir}
+Libs: -L$${libdir} -llog.c
+`
+	os.writeFile(filepath.join(pkgconfigDir, "log.c.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("log.c")!
 }
 
 onTest ctx => {
@@ -102,12 +111,13 @@ onTest ctx => {
 
 	shared := slices.contains(target.options["shared"], "ON")
 	binary := filepath.join(testDir, "consumer")
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "log.c.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("log.c")!), 0o644)!
 	args := []string{
 		sourcePath,
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-llog.c",
 		"-o", binary,
+		"@" + flagsFile,
 	}
 	cc! args...
 

--- a/rxi/log.c/f9ea34994bd58ed342d2245cd4110bb5c6790153/log_llar.gox
+++ b/rxi/log.c/f9ea34994bd58ed342d2245cd4110bb5c6790153/log_llar.gox
@@ -1,0 +1,121 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+var cmakeLists = `cmake_minimum_required(VERSION 3.8)
+project(log.c LANGUAGES C)
+
+option(LOGC_USE_COLOR "Use Color" ON)
+
+add_library(log.c $${LOGC_SRC_FOLDER}/src/log.c)
+set_target_properties(log.c PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+target_compile_features(log.c PRIVATE c_std_99)
+
+if(LOGC_USE_COLOR)
+    target_compile_definitions(log.c PRIVATE LOG_USE_COLOR)
+endif()
+
+include(GNUInstallDirs)
+install(FILES $${LOGC_SRC_FOLDER}/src/log.h DESTINATION $${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    TARGETS log.c
+    LIBRARY DESTINATION $${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION $${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION $${CMAKE_INSTALL_BINDIR}
+)
+`
+
+const consumerSource = `#include <log.h>
+
+int main(void) {
+    log_trace("Hello %s", "world");
+    log_trace(log_level_string(0));
+    return 0;
+}
+`
+
+id "rxi/log.c"
+
+fromVer "f9ea34994bd58ed342d2245cd4110bb5c6790153"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"color": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" && name != "color" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	cmakeDir := filepath.join(ctx.SourceDir, "_llar_cmake")
+	os.mkdirAll(cmakeDir, 0o755)!
+	os.writeFile(filepath.join(cmakeDir, "CMakeLists.txt"), []byte(cmakeLists), 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	color := slices.contains(target.options["color"], "ON")
+
+	c := cmake.new(cmakeDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "LOGC_SRC_FOLDER", ctx.SourceDir
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "LOGC_USE_COLOR", color
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-llog.c",
+	}
+	ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	sourcePath := filepath.join(testDir, "consumer.c")
+	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	binary := filepath.join(testDir, "consumer")
+	args := []string{
+		sourcePath,
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-llog.c",
+		"-o", binary,
+	}
+	exec "cc", args...
+	lastErr!
+
+	if shared {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary
+	lastErr!
+}

--- a/rxi/log.c/f9ea34994bd58ed342d2245cd4110bb5c6790153/log_llar.gox
+++ b/rxi/log.c/f9ea34994bd58ed342d2245cd4110bb5c6790153/log_llar.gox
@@ -109,13 +109,11 @@ onTest ctx => {
 		"-llog.c",
 		"-o", binary,
 	}
-	exec "cc", args...
-	lastErr!
+	cc! args...
 
 	if shared {
 		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 	}
-	exec binary
-	lastErr!
+	exec! binary
 }

--- a/rxi/log.c/versions.json
+++ b/rxi/log.c/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "rxi/log.c",
+	"deps": {}
+}


### PR DESCRIPTION
## Summary

- add the `rxi/log.c` Formula for upstream commit `f9ea34994bd58ed342d2245cd4110bb5c6790153`
- translate the Conan CMake build with `shared`, `fPIC`, and `color` options
- install the public header, library, and license, publish verified consumer flags, and run an independent C consumer test

## Evidence

The CCI snapshot `ffe30df101afd4dc95aac2f14b25bf345e64d7be` contains only `cci.20200620`; upstream exposes only `master` at the selected commit and has no tags or other heads, so no comparator is added.

## Validation

- `/tmp/llar-main-bin test -v ./@f9ea34994bd58ed342d2245cd4110bb5c6790153 --os darwin --arch arm64` (exit 0)
- repeated command exercised the cache-hit `onTest` path (exit 0)
- `git diff --cached --check` (clean)
