### PR TITLE
feat(libatomic_ops): add LLAR formula

### DIFF
--- a/bdwgc/libatomic_ops/v7.8.0/libatomic_llar.gox
+++ b/bdwgc/libatomic_ops/v7.8.0/libatomic_llar.gox
@@ -115,10 +115,14 @@ onBuild ctx => {
 	}
 
 	// CMake writes the upstream pkg-config file with the build prefix. Keep
-	// its verified flags while making the installed package relocatable.
+	// its verified flags while making the installed package relocatable and
+	// exposing the GPL extension's transitive core-library dependency.
 	pcPath := filepath.join(installDir, "lib", "pkgconfig", "atomic_ops.pc")
 	pc := string(os.readFile(pcPath)!)
 	pc = strings.replace(pc, "prefix="+installDir, "prefix=$${pcfiledir}/../..", 1)
+	pc = strings.replace(pc, "libdir="+filepath.join(installDir, "lib"), "libdir=$${prefix}/lib", 1)
+	pc = strings.replace(pc, "includedir="+filepath.join(installDir, "include"), "includedir=$${prefix}/include", 1)
+	pc = strings.replace(pc, "Libs: -L$${libdir} -latomic_ops", "Libs: -L$${libdir} -latomic_ops_gpl -latomic_ops", 1)
 	os.writeFile(pcPath, []byte(pc), 0o644)!
 
 	pkgconfig.use installDir
@@ -128,29 +132,21 @@ onBuild ctx => {
 onTest ctx => {
 	installDir := ctx.outputDir
 	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
-	testBuild := filepath.join(testDir, "_build")
 	os.mkdirAll(testDir, 0o755)!
-	os.writeFile(filepath.join(testDir, "consumer.c"), []byte(consumerSource), 0o644)!
+	consumer := filepath.join(testDir, "consumer.c")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
 
-	cmakeLists := `cmake_minimum_required(VERSION 3.15)
-project(libatomic_ops_consumer C)
+	pkgconfig.use installDir
+	flags := pkgconfig.lookup("atomic_ops")!
+	flagsFile := filepath.join(testDir, "atomic_ops.flags")
+	os.writeFile(flagsFile, []byte(flags), 0o644)!
 
-find_package(Atomic_ops CONFIG REQUIRED)
-
-add_executable(consumer consumer.c)
-target_link_libraries(consumer PRIVATE Atomic_ops::atomic_ops Atomic_ops::atomic_ops_gpl)
-`
-	os.writeFile(filepath.join(testDir, "CMakeLists.txt"), []byte(cmakeLists), 0o644)!
-
-	c := cmake.new(testDir, testBuild, "")
-	c.use installDir
-	c.configure
-	c.build
+	binary := filepath.join(testDir, "consumer")
+	cc! "-std=c11", consumer, "-o", binary, "@"+flagsFile
 
 	if target.options["shared"][0] == "ON" {
 		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 	}
-	exec filepath.join(testBuild, "consumer")
-	lastErr!
+	exec! binary
 }

--- a/bdwgc/libatomic_ops/v7.8.0/libatomic_llar.gox
+++ b/bdwgc/libatomic_ops/v7.8.0/libatomic_llar.gox
@@ -1,0 +1,156 @@
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const consumerSource = `#include "atomic_ops_stack.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+AO_t globalElement;
+
+AO_stack_t globalStack = AO_STACK_INITIALIZER;
+
+typedef struct {
+    AO_t head;
+    unsigned val;
+} my_stack_t;
+
+int main(void)
+{
+    AO_store_full(&globalElement, 1337);
+    {
+        AO_t val = AO_load_full(&globalElement);
+        if (val != 1337) {
+            fprintf(stderr, "Unexpected element after store/load: %u\n", (unsigned) val);
+            return EXIT_FAILURE;
+        }
+    }
+
+    {
+        my_stack_t *newElem = (my_stack_t *) malloc(sizeof(my_stack_t));
+        newElem->val = 4242;
+        AO_stack_push_release(&globalStack, &newElem->head);
+    }
+    {
+        my_stack_t *newElem = (my_stack_t *) malloc(sizeof(my_stack_t));
+        newElem->val = 8484;
+        AO_stack_push_release(&globalStack, &newElem->head);
+    }
+
+    {
+        my_stack_t *fetchElement = (my_stack_t *) AO_stack_pop_acquire(&globalStack);
+        if (fetchElement->val != 8484) {
+            fprintf(stderr, "Unexpected element from stack: %u\n", (unsigned) fetchElement->val);
+            return EXIT_FAILURE;
+        }
+        free(fetchElement);
+    }
+    {
+        my_stack_t *fetchElement = (my_stack_t *) AO_stack_pop_acquire(&globalStack);
+        if (fetchElement->val != 4242) {
+            fprintf(stderr, "Unexpected element from stack: %u\n", (unsigned) fetchElement->val);
+            return EXIT_FAILURE;
+        }
+        free(fetchElement);
+    }
+    return EXIT_SUCCESS;
+}
+`
+
+id "bdwgc/libatomic_ops"
+
+fromVer "v7.8.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"assertions": "OFF",
+	"atomic_intrinsics": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" && name != "assertions" && name != "atomic_intrinsics" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := target.options["shared"][0] == "ON"
+	fPIC := target.options["fPIC"][0] == "ON"
+	assertions := target.options["assertions"][0] == "ON"
+	atomicIntrinsics := target.options["atomic_intrinsics"][0] == "ON"
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.define "CMAKE_POLICY_VERSION_MINIMUM", "3.5"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "AO_BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "enable_assertions", assertions
+	c.defineBool "enable_atomic_intrinsics", atomicIntrinsics
+	c.defineBool "BUILD_TESTING", false
+	c.defineBool "enable_gpl", true
+	c.defineBool "install_headers", true
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	for name in []string{"LICENSE", "COPYING"} {
+		license := os.readFile(filepath.join(ctx.SourceDir, name))!
+		os.writeFile(filepath.join(licenseDir, name), license, 0o644)!
+	}
+
+	// CMake writes the upstream pkg-config file with the build prefix. Keep
+	// its verified flags while making the installed package relocatable.
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", "atomic_ops.pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix="+installDir, "prefix=$${pcfiledir}/../..", 1)
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("atomic_ops")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	testBuild := filepath.join(testDir, "_build")
+	os.mkdirAll(testDir, 0o755)!
+	os.writeFile(filepath.join(testDir, "consumer.c"), []byte(consumerSource), 0o644)!
+
+	cmakeLists := `cmake_minimum_required(VERSION 3.15)
+project(libatomic_ops_consumer C)
+
+find_package(Atomic_ops CONFIG REQUIRED)
+
+add_executable(consumer consumer.c)
+target_link_libraries(consumer PRIVATE Atomic_ops::atomic_ops Atomic_ops::atomic_ops_gpl)
+`
+	os.writeFile(filepath.join(testDir, "CMakeLists.txt"), []byte(cmakeLists), 0o644)!
+
+	c := cmake.new(testDir, testBuild, "")
+	c.use installDir
+	c.configure
+	c.build
+
+	if target.options["shared"][0] == "ON" {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec filepath.join(testBuild, "consumer")
+	lastErr!
+}

--- a/bdwgc/libatomic_ops/versions.json
+++ b/bdwgc/libatomic_ops/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "bdwgc/libatomic_ops",
+	"deps": {}
+}


### PR DESCRIPTION
## Summary
- add the `bdwgc/libatomic_ops` Formula from CCI snapshot `ffe30df`
- support upstream CMake releases from `v7.8.0`, including `v7.10.0`
- publish relocatable `atomic_ops.pc` metadata and an independent C consumer

## Validation
- `/tmp/llar-b416 test --verbose ./bdwgc/libatomic_ops@v7.10.0`
- `/tmp/llar-b416 test --verbose ./bdwgc/libatomic_ops@v7.8.0`
- repeated v7.10.0 test exercised cache-hit onTest
- complete upstream tag set (52 refs) checked against LLAR GNU comparator; no custom comparator needed