### PR TITLE
feat(ctrl-c): add LLAR formula

### DIFF
--- a/evgenykislov/ctrl-c/v1.0.0/CMakeLists.txt
+++ b/evgenykislov/ctrl-c/v1.0.0/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.15)
+project(ctrl-c LANGUAGES CXX)
+
+add_library(ctrl-c ${CTRL_C_SRC_DIR}/src/ctrl-c.cpp)
+set_target_properties(ctrl-c PROPERTIES
+    PUBLIC_HEADER ${CTRL_C_SRC_DIR}/src/ctrl-c.h
+)
+target_compile_features(ctrl-c PUBLIC cxx_std_11)
+
+include(GNUInstallDirs)
+install(
+    TARGETS ctrl-c
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/evgenykislov/ctrl-c/v1.0.0/ctrl_c_llar.gox
+++ b/evgenykislov/ctrl-c/v1.0.0/ctrl_c_llar.gox
@@ -1,0 +1,96 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include "ctrl-c.h"
+
+int main(void) {
+    auto id = CtrlCLibrary::SetCtrlCHandler([](CtrlCLibrary::CtrlSignal signal){ return true;});
+    CtrlCLibrary::ResetCtrlCHandler(id);
+
+    return 0;
+}
+`
+
+id "evgenykislov/ctrl-c"
+
+fromVer "v1.0.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	cmakeLists := ctx.Proj.readFile("v1.0.0/CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CTRL_C_SRC_DIR", ctx.SourceDir
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lctrl-c",
+	}
+	ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	sourcePath := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	args := []string{
+		"-std=c++11",
+		"-I" + filepath.join(installDir, "include"),
+		sourcePath,
+		"-L" + filepath.join(installDir, "lib"),
+		"-lctrl-c",
+		"-o", binary,
+	}
+	exec "c++", args...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary
+	lastErr!
+}

--- a/evgenykislov/ctrl-c/versions.json
+++ b/evgenykislov/ctrl-c/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "evgenykislov/ctrl-c",
+	"deps": {}
+}


### PR DESCRIPTION
Closes #96.

Adds the `evgenykislov/ctrl-c` LLAR Formula for upstream `v1.0.0` from the Conan Center snapshot `ffe30df101afd4dc95aac2f14b25bf345e64d7be`.

- Carries the CCI-exported CMake entrypoint and maps the verified `shared`/`fPIC` options.
- Installs the public header, `libctrl-c`, and MIT license with direct consumer metadata.
- Adds an independent C++11 consumer check based on the CCI test package.
- Upstream exposes only one version tag (`v1.0.0`), so no comparator is needed.

Validation: `git diff --cached --check` (clean). Local LLAR/CI tests were intentionally not awaited per request.