### PR TITLE
feat(libschrift): add LLAR formula

### DIFF
--- a/tomolt/libschrift/CMakeLists.txt
+++ b/tomolt/libschrift/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.8)
+project(schrift LANGUAGES C)
+
+include(GNUInstallDirs)
+
+add_library(schrift ${LIBSCHRIFT_SRC_DIR}/schrift.c)
+set_target_properties(schrift PROPERTIES
+    PUBLIC_HEADER ${LIBSCHRIFT_SRC_DIR}/schrift.h
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+    C_EXTENSIONS OFF
+    C_STANDARD 99
+)
+
+find_library(LIBM m)
+target_link_libraries(schrift PRIVATE $<$<BOOL:${LIBM}>:${LIBM}>)
+
+install(
+    TARGETS schrift
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/tomolt/libschrift/v0.10.1/libschrift_llar.gox
+++ b/tomolt/libschrift/v0.10.1/libschrift_llar.gox
@@ -1,0 +1,109 @@
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+)
+
+const consumerSource = `#include <stdio.h>
+#include <stdlib.h>
+
+#include "schrift.h"
+
+int main(void)  {
+    printf("Schrift version: %s\n", sft_version());
+
+    return EXIT_SUCCESS;
+}
+`
+
+id "tomolt/libschrift"
+
+fromVer "v0.10.1"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	cmakeLists := ctx.Proj.readFile("CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "LIBSCHRIFT_SRC_DIR", ctx.SourceDir
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0644)!
+
+	osName := runtime.GOOS
+	osValues := target.require["os"]
+	if osValues.len > 0 {
+		osName = osValues[0]
+	}
+	metadata := "-I" + filepath.join(installDir, "include") + " -L" + filepath.join(installDir, "lib") + " -lschrift"
+	if osName == "linux" || osName == "freebsd" {
+		metadata += " -lm"
+	}
+	ctx.setMetadata metadata
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0755)!
+
+	consumer := filepath.join(testDir, "consumer.c")
+	os.writeFile(consumer, []byte(consumerSource), 0644)!
+
+	osName := runtime.GOOS
+	osValues := target.require["os"]
+	if osValues.len > 0 {
+		osName = osValues[0]
+	}
+	args := []string{
+		"-I" + filepath.join(installDir, "include"),
+		consumer,
+		"-L" + filepath.join(installDir, "lib"),
+		"-lschrift",
+	}
+	if osName == "linux" || osName == "freebsd" {
+		args = append(args, "-lm")
+	}
+	binary := filepath.join(testDir, "consumer")
+	args = append(args, "-o", binary)
+	exec "cc", args...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary
+	lastErr!
+}

--- a/tomolt/libschrift/v0.10.1/libschrift_llar.gox
+++ b/tomolt/libschrift/v0.10.1/libschrift_llar.gox
@@ -3,6 +3,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 )
 
 const consumerSource = `#include <stdio.h>
@@ -66,10 +67,41 @@ onBuild ctx => {
 	if osValues.len > 0 {
 		osName = osValues[0]
 	}
-	metadata := "-I" + filepath.join(installDir, "include") + " -L" + filepath.join(installDir, "lib") + " -lschrift"
-	if osName == "linux" || osName == "freebsd" {
-		metadata += " -lm"
+
+	source := string(os.readFile(filepath.join(ctx.SourceDir, "schrift.c"))!)
+	versionNeedle := `#define SCHRIFT_VERSION "`
+	versionStart := strings.index(source, versionNeedle)
+	if versionStart < 0 {
+		panic "libschrift source does not define SCHRIFT_VERSION"
 	}
+	versionStart += versionNeedle.len
+	versionEnd := strings.index(source[versionStart:], `"`)
+	if versionEnd < 0 {
+		panic "libschrift SCHRIFT_VERSION is not terminated"
+	}
+	version := source[versionStart : versionStart+versionEnd]
+
+	libs := "-L$${libdir} -lschrift"
+	if osName == "linux" || osName == "freebsd" {
+		libs += " -lm"
+	}
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: libschrift
+Description: lightweight TrueType font rendering library
+Version: ` + version + `
+Libs: ` + libs + `
+Cflags: -I$${includedir}
+`
+	pkgconfigDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pkgconfigDir, 0755)!
+	os.writeFile(filepath.join(pkgconfigDir, "libschrift.pc"), []byte(pc), 0644)!
+
+	pkgconfig.use installDir
+	metadata := pkgconfig.lookup("libschrift")!
 	ctx.setMetadata metadata
 }
 
@@ -81,29 +113,25 @@ onTest ctx => {
 	consumer := filepath.join(testDir, "consumer.c")
 	os.writeFile(consumer, []byte(consumerSource), 0644)!
 
-	osName := runtime.GOOS
-	osValues := target.require["os"]
-	if osValues.len > 0 {
-		osName = osValues[0]
-	}
-	args := []string{
-		"-I" + filepath.join(installDir, "include"),
-		consumer,
-		"-L" + filepath.join(installDir, "lib"),
-		"-lschrift",
-	}
-	if osName == "linux" || osName == "freebsd" {
-		args = append(args, "-lm")
-	}
+	pkgconfig.use installDir
+	flags := [strings.replace(flag, `\|`, "|", -1) for flag in strings.fields(pkgconfig.lookup("libschrift")!)]
+	args := []string{consumer}
+	args <- flags...
 	binary := filepath.join(testDir, "consumer")
-	args = append(args, "-o", binary)
-	exec "cc", args...
-	lastErr!
+	args <- "-o", binary
+	cc! args...
 
 	if slices.contains(target.options["shared"], "ON") {
-		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
-		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		osName := runtime.GOOS
+		osValues := target.require["os"]
+		if osValues.len > 0 {
+			osName = osValues[0]
+		}
+		if osName == "darwin" {
+			os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		} else {
+			os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		}
 	}
-	exec binary
-	lastErr!
+	exec! binary
 }

--- a/tomolt/libschrift/versions.json
+++ b/tomolt/libschrift/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "tomolt/libschrift",
+	"deps": {}
+}


### PR DESCRIPTION
Adds a LLAR Formula for tomolt/libschrift.

- Supports upstream tags v0.10.1 and v0.10.2 from the Conan Center recipe.
- Builds and installs the C library with the verified CMake wrapper.
- Publishes consumer flags and tests sft_version() against the installed artifact.

Validation: git diff --cached --check passed. Local formula tests and CI were intentionally not run per request.