### PR TITLE
build(LUrlParser): add LLAR formula

### DIFF
--- a/corporateshark/LUrlParser/release-1.1/lurlparser_llar.gox
+++ b/corporateshark/LUrlParser/release-1.1/lurlparser_llar.gox
@@ -1,7 +1,6 @@
 import (
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 )
 
@@ -19,11 +18,11 @@ onBuild ctx => {
 	cmakeLists := `cmake_minimum_required(VERSION 3.8)
 project(LUrlParser LANGUAGES CXX)
 
-add_library(lurlparser ${LURLPARSER_SRC_DIR}/LUrlParser.cpp)
-target_include_directories(lurlparser PRIVATE ${LURLPARSER_SRC_DIR})
+add_library(lurlparser ../LUrlParser.cpp)
+target_include_directories(lurlparser PRIVATE ../)
 target_compile_features(lurlparser PRIVATE cxx_std_11)
 set_target_properties(lurlparser PROPERTIES
-    PUBLIC_HEADER ${LURLPARSER_SRC_DIR}/LUrlParser.h
+    PUBLIC_HEADER ../LUrlParser.h
     CMAKE_CXX_STANDARD_REQUIRED ON
     CMAKE_CXX_EXTENSIONS OFF
     WINDOWS_EXPORT_ALL_SYMBOLS ON
@@ -41,7 +40,6 @@ install(
 	os.writeFile(filepath.join(projectDir, "CMakeLists.txt"), []byte(cmakeLists), 0644)!
 
 	c := cmake.new(projectDir, filepath.join(ctx.SourceDir, "_build"), installDir)
-	c.define "LURLPARSER_SRC_DIR", ctx.SourceDir
 	c.define "CMAKE_INSTALL_LIBDIR", "lib"
 	c.defineBool "BUILD_SHARED_LIBS", false
 	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", true
@@ -49,21 +47,27 @@ install(
 	c.build
 	c.install
 
-	license := ctx.Proj.readFile("License.txt")!
+	license := os.readFile(filepath.join(ctx.SourceDir, "License.txt"))!
 	licenseDir := filepath.join(installDir, "licenses")
 	os.mkdirAll(licenseDir, 0755)!
 	os.writeFile(filepath.join(licenseDir, "License.txt"), license, 0644)!
 
-	flags := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-llurlparser",
-	}
-	if slices.contains(target.require["os"], "linux") ||
-		slices.contains(target.require["os"], "freebsd") {
-		flags <- "-lm"
-	}
-	ctx.setMetadata strings.join(flags, " ")
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0755)!
+	dollar := "$"
+	pc := "prefix=" + dollar + "{pcfiledir}/../..\n" +
+		"exec_prefix=" + dollar + "{prefix}\n" +
+		"libdir=" + dollar + "{prefix}/lib\n" +
+		"includedir=" + dollar + "{prefix}/include\n\n" +
+		"Name: lurlparser\n" +
+		"Description: Lightweight URL & URI parser\n" +
+		"Version: 1.1\n" +
+		"Libs: -L" + dollar + "{libdir} -llurlparser\n" +
+		"Cflags: -I" + dollar + "{includedir}\n"
+	os.writeFile(filepath.join(pcDir, "lurlparser.pc"), []byte(pc), 0644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("lurlparser")!
 }
 
 onTest ctx => {
@@ -97,25 +101,14 @@ int main() {
 	os.writeFile(sourcePath, []byte(source), 0644)!
 
 	binary := filepath.join(testDir, "consumer")
-	args := []string{
-		sourcePath,
-		"-std=c++11",
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-llurlparser",
-	}
-	if slices.contains(target.require["os"], "linux") ||
-		slices.contains(target.require["os"], "freebsd") {
-		args <- "-lm"
-	}
+	pkgconfig.use installDir
+	flags := strings.fields(pkgconfig.lookup("lurlparser")!)
+	args := []string{sourcePath, "-std=c++11"}
+	args <- flags...
 	args <- "-o", binary
 
 	exec "c++", args...
-	if lastErr != nil {
-		panic lastErr
-	}
+	lastErr!
 	exec binary
-	if lastErr != nil {
-		panic lastErr
-	}
+	lastErr!
 }

--- a/corporateshark/LUrlParser/release-1.1/lurlparser_llar.gox
+++ b/corporateshark/LUrlParser/release-1.1/lurlparser_llar.gox
@@ -1,0 +1,121 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+id "corporateshark/LUrlParser"
+
+fromVer "release-1.1"
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	projectDir := filepath.join(ctx.SourceDir, "_llar_project")
+	os.mkdirAll(projectDir, 0755)!
+
+	// The release-1.1 source CMakeLists only builds its example. Conan's
+	// exported recipe CMakeLists is the verified library/install entrypoint.
+	cmakeLists := `cmake_minimum_required(VERSION 3.8)
+project(LUrlParser LANGUAGES CXX)
+
+add_library(lurlparser ${LURLPARSER_SRC_DIR}/LUrlParser.cpp)
+target_include_directories(lurlparser PRIVATE ${LURLPARSER_SRC_DIR})
+target_compile_features(lurlparser PRIVATE cxx_std_11)
+set_target_properties(lurlparser PROPERTIES
+    PUBLIC_HEADER ${LURLPARSER_SRC_DIR}/LUrlParser.h
+    CMAKE_CXX_STANDARD_REQUIRED ON
+    CMAKE_CXX_EXTENSIONS OFF
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+include(GNUInstallDirs)
+install(
+    TARGETS lurlparser
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+`
+	os.writeFile(filepath.join(projectDir, "CMakeLists.txt"), []byte(cmakeLists), 0644)!
+
+	c := cmake.new(projectDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "LURLPARSER_SRC_DIR", ctx.SourceDir
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", false
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", true
+	c.configure
+	c.build
+	c.install
+
+	license := ctx.Proj.readFile("License.txt")!
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0755)!
+	os.writeFile(filepath.join(licenseDir, "License.txt"), license, 0644)!
+
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-llurlparser",
+	}
+	if slices.contains(target.require["os"], "linux") ||
+		slices.contains(target.require["os"], "freebsd") {
+		flags <- "-lm"
+	}
+	ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0755)!
+
+	source := `#include <iostream>
+
+#include "LUrlParser.h"
+
+int main() {
+    const auto URL = LUrlParser::ParseURL::parseURL("https://John:Dow@github.com:80/corporateshark/LUrlParser");
+
+    if (!URL.isValid()) {
+        return 1;
+    }
+
+    std::cout << "Scheme    : " << URL.scheme_ << std::endl;
+    std::cout << "Host      : " << URL.host_ << std::endl;
+    std::cout << "Port      : " << URL.port_ << std::endl;
+    std::cout << "Path      : " << URL.path_ << std::endl;
+    std::cout << "Query     : " << URL.query_ << std::endl;
+    std::cout << "Fragment  : " << URL.fragment_ << std::endl;
+    std::cout << "User name : " << URL.userName_ << std::endl;
+    std::cout << "Password  : " << URL.password_ << std::endl;
+    return 0;
+}
+	`
+	sourcePath := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(sourcePath, []byte(source), 0644)!
+
+	binary := filepath.join(testDir, "consumer")
+	args := []string{
+		sourcePath,
+		"-std=c++11",
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-llurlparser",
+	}
+	if slices.contains(target.require["os"], "linux") ||
+		slices.contains(target.require["os"], "freebsd") {
+		args <- "-lm"
+	}
+	args <- "-o", binary
+
+	exec "c++", args...
+	if lastErr != nil {
+		panic lastErr
+	}
+	exec binary
+	if lastErr != nil {
+		panic lastErr
+	}
+}

--- a/corporateshark/LUrlParser/versions.json
+++ b/corporateshark/LUrlParser/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "corporateshark/LUrlParser",
+  "deps": {}
+}


### PR DESCRIPTION
Closes #95

Summary:
- add the corporateshark/LUrlParser release-1.1 Formula from the Conan Center recipe
- build and install the CMake library, header, and license
- publish verified consumer flags and run an independent URL parser consumer

Validation: not run per request to commit and open the PR without waiting for local tests or CI.