### PR TITLE
feat(libaesgm): add LLAR formula

### DIFF
--- a/xmake-mirror/libaesgm/2013.1.1/libaesgm_llar.gox
+++ b/xmake-mirror/libaesgm/2013.1.1/libaesgm_llar.gox
@@ -62,12 +62,26 @@ onBuild ctx => {
 	os.mkdirAll(licenseDir, 0o755)!
 	os.writeFile(filepath.join(licenseDir, "LICENSE"), []byte(license), 0o644)!
 
-	metadata := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-lAesgm",
-	}
-	ctx.setMetadata strings.join(metadata, " ")
+	// The upstream 2013.1.1 source has no package metadata. Publish the
+	// installed Aesgm interface as a relocatable pkg-config file instead of
+	// embedding this build's output directory in Formula metadata.
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: Aesgm
+Description: Library implementation of AES cryptographic methods
+Version: 2013.1.1
+Libs: -L$${libdir} -lAesgm
+Cflags: -I$${includedir}
+`
+	os.writeFile(filepath.join(pcDir, "Aesgm.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("Aesgm")!
 }
 
 onTest ctx => {
@@ -78,20 +92,16 @@ onTest ctx => {
 	sourcePath := filepath.join(testDir, "consumer.c")
 	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
 	binary := filepath.join(testDir, "consumer")
-	args := []string{
-		"-I" + filepath.join(installDir, "include"),
-		sourcePath,
-		"-L" + filepath.join(installDir, "lib"),
-		"-lAesgm",
-		"-o", binary,
-	}
-	exec "cc", args...
-	lastErr!
+
+	pkgconfig.use installDir
+	flags := pkgconfig.lookup("Aesgm")!
+	flagsFile := filepath.join(testDir, "Aesgm.flags")
+	os.writeFile(flagsFile, []byte(flags), 0o644)!
+	cc! sourcePath, "@"+flagsFile, "-o", binary
 
 	if slices.contains(target.options["shared"], "ON") {
 		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 	}
-	exec binary
-	lastErr!
+	exec! binary
 }

--- a/xmake-mirror/libaesgm/2013.1.1/libaesgm_llar.gox
+++ b/xmake-mirror/libaesgm/2013.1.1/libaesgm_llar.gox
@@ -1,0 +1,97 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <aes.h>
+
+int main() {
+    aes_encrypt_ctx ctx;
+    char message[] = "test";
+    char key[] = "0123456789ABCDEF";
+    aes_encrypt(message, key, &ctx);
+
+    return 0;
+}
+`
+
+id "xmake-mirror/libaesgm"
+
+fromVer "2013.1.1"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	cmakeLists := ctx.Proj.readFile("CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "LIBAESGM_SRC_DIR", ctx.SourceDir
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	license := string(os.readFile(filepath.join(ctx.SourceDir, "aes.h"))!)
+	licenseEnd := strings.index(license, "*/")
+	license = strings.replace(license[:licenseEnd], "/*", "", 1)
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), []byte(license), 0o644)!
+
+	metadata := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lAesgm",
+	}
+	ctx.setMetadata strings.join(metadata, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	sourcePath := filepath.join(testDir, "consumer.c")
+	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
+	binary := filepath.join(testDir, "consumer")
+	args := []string{
+		"-I" + filepath.join(installDir, "include"),
+		sourcePath,
+		"-L" + filepath.join(installDir, "lib"),
+		"-lAesgm",
+		"-o", binary,
+	}
+	exec "cc", args...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary
+	lastErr!
+}

--- a/xmake-mirror/libaesgm/CMakeLists.txt
+++ b/xmake-mirror/libaesgm/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.8)
+project(LibAesgm LANGUAGES C)
+
+add_library(Aesgm
+    #sources
+    ${LIBAESGM_SRC_DIR}/aescrypt.c
+    ${LIBAESGM_SRC_DIR}/aeskey.c
+    ${LIBAESGM_SRC_DIR}/aes_modes.c
+    ${LIBAESGM_SRC_DIR}/aes_ni.c
+    ${LIBAESGM_SRC_DIR}/aestab.c
+    #headers
+    ${LIBAESGM_SRC_DIR}/aescpp.h
+    ${LIBAESGM_SRC_DIR}/aes.h
+    ${LIBAESGM_SRC_DIR}/aes_ni.h
+    ${LIBAESGM_SRC_DIR}/aesopt.h
+    ${LIBAESGM_SRC_DIR}/aestab.h
+    ${LIBAESGM_SRC_DIR}/aes_via_ace.h
+    ${LIBAESGM_SRC_DIR}/brg_endian.h
+    ${LIBAESGM_SRC_DIR}/brg_types.h
+)
+
+target_include_directories(Aesgm
+    INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/LibAesgm>
+)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    target_compile_definitions(Aesgm PRIVATE DLL_EXPORT)
+endif()
+
+install(TARGETS Aesgm
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(
+    FILES
+    ${LIBAESGM_SRC_DIR}/aes.h
+    ${LIBAESGM_SRC_DIR}/aes_ni.h
+    ${LIBAESGM_SRC_DIR}/aes_via_ace.h
+    ${LIBAESGM_SRC_DIR}/aescpp.h
+    ${LIBAESGM_SRC_DIR}/aesopt.h
+    ${LIBAESGM_SRC_DIR}/aestab.h
+    ${LIBAESGM_SRC_DIR}/brg_endian.h
+    ${LIBAESGM_SRC_DIR}/brg_types.h
+    DESTINATION include
+)

--- a/xmake-mirror/libaesgm/versions.json
+++ b/xmake-mirror/libaesgm/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "xmake-mirror/libaesgm",
+	"deps": {}
+}


### PR DESCRIPTION
Closes #92

- Add the xmake-mirror/libaesgm LLAR Formula for upstream 2013.1.1.
- Preserve the Conan Center CMake build/install layout, shared/fPIC options, license, and consumer verification.
- Publish direct include/library metadata for the installed Aesgm library.

Source evidence: Conan Center snapshot ffe30df101afd4dc95aac2f14b25bf345e64d7be.