### PR TITLE
feat(neco): add LLAR formula

### DIFF
--- a/tidwall/neco/v0.3.2/CMakeLists.txt
+++ b/tidwall/neco/v0.3.2/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.15)
+project(neco LANGUAGES C)
+
+include(GNUInstallDirs)
+
+add_library(neco ${TIDWALL_NECO_SRC_DIR}/neco.c)
+target_include_directories(neco PRIVATE ${TIDWALL_NECO_SRC_DIR})
+set_target_properties(neco PROPERTIES
+    PUBLIC_HEADER ${TIDWALL_NECO_SRC_DIR}/neco.h
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+target_compile_features(neco PRIVATE c_std_11)
+
+install(
+    TARGETS neco
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/tidwall/neco/v0.3.2/neco_llar.gox
+++ b/tidwall/neco/v0.3.2/neco_llar.gox
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) {
 
 id "tidwall/neco"
 
-fromVer "v0.3.2"
+fromVer "v0.1.0"
 
 defaults {
 	"shared": "OFF",
@@ -60,18 +60,34 @@ onBuild ctx => {
 
 	licenseDir := filepath.join(installDir, "licenses")
 	os.mkdirAll(licenseDir, 0o755)!
-	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+	license := os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), license, 0o644)!
 
-	flags := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-lneco",
-	}
+	// LLAR checks out the selected tag into a shallow repository; use FETCH_HEAD
+	// so the installed metadata reports the exact source version.
+	fetchHead := string(os.readFile(filepath.join(ctx.SourceDir, ".git", "FETCH_HEAD"))!)
+	version := fetchHead.splitN("'", 3)[1][1:]
+	libs := "-L$${libdir} -lneco"
 	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
-		flags <- "-lpthread"
-		flags <- "-ldl"
+		libs += " -lpthread -ldl"
 	}
-	ctx.setMetadata strings.join(flags, " ")
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: neco
+Description: Coroutine library for C
+Version: ` + version + `
+Libs: ` + libs + `
+Cflags: -I$${includedir}
+`
+	os.writeFile(filepath.join(pcDir, "neco.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("neco")!
 }
 
 onTest ctx => {
@@ -82,26 +98,17 @@ onTest ctx => {
 	sourcePath := filepath.join(testDir, "consumer.c")
 	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
 	binary := filepath.join(testDir, "consumer")
-	args := []string{
-		"-std=c11",
-		"-I" + filepath.join(installDir, "include"),
-		sourcePath,
-		"-L" + filepath.join(installDir, "lib"),
-		"-lneco",
-	}
-	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
-		args <- "-lpthread"
-		args <- "-ldl"
-	}
-	args <- "-o"
-	args <- binary
-	exec "cc", args...
-	lastErr!
+
+	pkgconfig.use installDir
+	flags := strings.replaceAll(pkgconfig.lookup("neco")!, "\\|", "|")
+	args := []string{sourcePath, "-std=c11"}
+	args <- strings.fields(flags)...
+	args <- []string{"-o", binary}...
+	cc! args...
 
 	if slices.contains(target.options["shared"], "ON") {
 		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 	}
-	exec binary
-	lastErr!
+	exec! binary
 }

--- a/tidwall/neco/v0.3.2/neco_llar.gox
+++ b/tidwall/neco/v0.3.2/neco_llar.gox
@@ -1,0 +1,107 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <stdio.h>
+
+#include "neco.h"
+
+void coroutine(int argc, void *argv[]) {
+    printf("main coroutine started\n");
+}
+
+int main(int argc, char *argv[]) {
+    neco_start(coroutine, 0);
+    return 0;
+}
+`
+
+id "tidwall/neco"
+
+fromVer "v0.3.2"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	cmakeLists := ctx.Proj.readFile("v0.3.2/CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "TIDWALL_NECO_SRC_DIR", ctx.SourceDir
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lneco",
+	}
+	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
+		flags <- "-lpthread"
+		flags <- "-ldl"
+	}
+	ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	sourcePath := filepath.join(testDir, "consumer.c")
+	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
+	binary := filepath.join(testDir, "consumer")
+	args := []string{
+		"-std=c11",
+		"-I" + filepath.join(installDir, "include"),
+		sourcePath,
+		"-L" + filepath.join(installDir, "lib"),
+		"-lneco",
+	}
+	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
+		args <- "-lpthread"
+		args <- "-ldl"
+	}
+	args <- "-o"
+	args <- binary
+	exec "cc", args...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary
+	lastErr!
+}

--- a/tidwall/neco/versions.json
+++ b/tidwall/neco/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "tidwall/neco",
+  "deps": {}
+}


### PR DESCRIPTION
Closes #88

- Add `tidwall/neco` Formula for `v0.3.2` from the specified Conan Center snapshot.
- Reuse the exported CMake build, publish headers/library/license, and preserve Linux/FreeBSD pthread/dl link metadata.
- Add the CCI consumer-equivalent coroutine check.

Validation: `git diff --check` passed. Per request, local tests and CI were not awaited.