### PR TITLE
feat(tinymidi): add LLAR formula

### DIFF
--- a/krgn/tinymidi/3162cf8faff04e26a8daa846618b90326f71b9d5/CMakeLists.txt
+++ b/krgn/tinymidi/3162cf8faff04e26a8daa846618b90326f71b9d5/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.15)
+project(tinymidi LANGUAGES C)
+
+add_library(tinymidi ${TINYMIDI_SRC_DIR}/rawmidi.c)
+
+include(GNUInstallDirs)
+install(FILES ${TINYMIDI_SRC_DIR}/include/rawmidi.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    TARGETS tinymidi
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/krgn/tinymidi/3162cf8faff04e26a8daa846618b90326f71b9d5/tinymidi_llar.gox
+++ b/krgn/tinymidi/3162cf8faff04e26a8daa846618b90326f71b9d5/tinymidi_llar.gox
@@ -63,38 +63,41 @@ onBuild ctx => {
 	os.mkdirAll(licenseDir, 0o755)!
 	os.writeFile(filepath.join(licenseDir, "COPYING"), os.readFile(filepath.join(ctx.SourceDir, "COPYING"))!, 0o644)!
 
-	metadata := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-ltinymidi",
-	}
-	ctx.setMetadata strings.join(metadata, " ")
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+includedir=$${prefix}/include
+libdir=$${prefix}/lib
+
+Name: tinymidi
+Description: A small C library for doing MIDI on GNU/Linux
+Version: 3162cf8faff04e26a8daa846618b90326f71b9d5
+Libs: -L$${libdir} -ltinymidi
+Cflags: -I$${includedir}
+`
+	os.writeFile(filepath.join(pcDir, "tinymidi.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("tinymidi")!
 }
 
 onTest ctx => {
 	installDir := ctx.outputDir
-	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	testDir := os.mkdirTemp("", "tinymidi-consumer-")!
+	defer os.removeAll(testDir)
 	testSource := filepath.join(testDir, "consumer.c")
-	testBuild := filepath.join(testDir, "_build")
-	binary := filepath.join(testBuild, "consumer")
-	os.mkdirAll(testDir, 0o755)!
-	os.mkdirAll(testBuild, 0o755)!
+	binary := filepath.join(testDir, "consumer")
 	os.writeFile(testSource, []byte(consumerSource), 0o644)!
 
-	args := []string{
-		testSource,
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-ltinymidi",
-		"-o", binary,
-	}
-	exec "cc", args...
-	lastErr!
+	pkgconfig.use installDir
+	args := []string{testSource}
+	args <- strings.fields(pkgconfig.lookup("tinymidi")!)...
+	args <- "-o", binary
+	cc! args...
 
 	if slices.contains(target.options["shared"], "ON") {
 		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 	}
-	exec binary
-	lastErr!
+	exec! binary
 }

--- a/krgn/tinymidi/3162cf8faff04e26a8daa846618b90326f71b9d5/tinymidi_llar.gox
+++ b/krgn/tinymidi/3162cf8faff04e26a8daa846618b90326f71b9d5/tinymidi_llar.gox
@@ -1,0 +1,100 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <rawmidi.h>
+
+int main(void) {
+    rawmidi_hw_print_info("/dev/midi");
+    return 0;
+}
+`
+
+// Conan Center cci.20130325 pins krgn/tinymidi to this untagged commit.
+id "krgn/tinymidi"
+
+fromVer "3162cf8faff04e26a8daa846618b90326f71b9d5"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	for value in target.require["os"] {
+		if value != "linux" && value != "freebsd" {
+			return false
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	cmakeLists := ctx.Proj.readFile("3162cf8faff04e26a8daa846618b90326f71b9d5/CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "TINYMIDI_SRC_DIR", ctx.SourceDir
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "COPYING"), os.readFile(filepath.join(ctx.SourceDir, "COPYING"))!, 0o644)!
+
+	metadata := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-ltinymidi",
+	}
+	ctx.setMetadata strings.join(metadata, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	testSource := filepath.join(testDir, "consumer.c")
+	testBuild := filepath.join(testDir, "_build")
+	binary := filepath.join(testBuild, "consumer")
+	os.mkdirAll(testDir, 0o755)!
+	os.mkdirAll(testBuild, 0o755)!
+	os.writeFile(testSource, []byte(consumerSource), 0o644)!
+
+	args := []string{
+		testSource,
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-ltinymidi",
+		"-o", binary,
+	}
+	exec "cc", args...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary
+	lastErr!
+}

--- a/krgn/tinymidi/versions.json
+++ b/krgn/tinymidi/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "krgn/tinymidi",
+  "deps": {}
+}


### PR DESCRIPTION
Adds a Formula for the Conan Center tinymidi recipe.

- Module: `krgn/tinymidi`
- CCI version: `cci.20130325`
- Source ref: `3162cf8faff04e26a8daa846618b90326f71b9d5`
- Supports the recipe's Linux/FreeBSD, shared, and fPIC choices
- Installs headers/library/license and tests the rawmidi consumer

Local tests were intentionally not run per request.