### PR TITLE
feat(microtar): add LLAR formula

### DIFF
--- a/rxi/microtar/v0.1.0/CMakeLists.txt
+++ b/rxi/microtar/v0.1.0/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.15)
+project(microtar LANGUAGES C)
+
+include(GNUInstallDirs)
+
+add_library(microtar ${MICROTAR_SRC_DIR}/src/microtar.c)
+set_target_properties(microtar PROPERTIES
+    PUBLIC_HEADER "${MICROTAR_SRC_DIR}/src/microtar.h"
+    WINDOWS_EXPORT_ALL_SYMBOLS ON
+)
+
+install(
+    TARGETS microtar
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)

--- a/rxi/microtar/v0.1.0/microtar_llar.gox
+++ b/rxi/microtar/v0.1.0/microtar_llar.gox
@@ -1,0 +1,115 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <microtar.h>
+
+int main(void) {
+    mtar_t tar;
+    const char *str1 = "Hello world";
+    const char *str2 = "Goodbye world";
+
+    if (mtar_open(&tar, "test.tar", "w") != MTAR_ESUCCESS) {
+        return EXIT_FAILURE;
+    }
+    if (mtar_write_file_header(&tar, "test1.txt", strlen(str1)) != MTAR_ESUCCESS ||
+        mtar_write_data(&tar, str1, strlen(str1)) != MTAR_ESUCCESS ||
+        mtar_write_file_header(&tar, "test2.txt", strlen(str2)) != MTAR_ESUCCESS ||
+        mtar_write_data(&tar, str2, strlen(str2)) != MTAR_ESUCCESS ||
+        mtar_finalize(&tar) != MTAR_ESUCCESS ||
+        mtar_close(&tar) != MTAR_ESUCCESS) {
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}
+`
+
+id "rxi/microtar"
+
+fromVer "v0.1.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	cmakeLists := ctx.Proj.readFile("v0.1.0/CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "MICROTAR_SRC_DIR", ctx.SourceDir
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	flags := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lmicrotar",
+	}
+	ctx.setMetadata strings.join(flags, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	sourcePath := filepath.join(testDir, "consumer.c")
+	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	args := []string{
+		sourcePath,
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lmicrotar",
+		"-o", binary,
+	}
+	exec "cc", args...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		if slices.contains(target.require["os"], "windows") {
+			path := os.getenv("PATH")
+			os.setenv("PATH", filepath.join(installDir, "bin")+";"+path)!
+		}
+	}
+
+	exec binary
+	lastErr!
+}

--- a/rxi/microtar/v0.1.0/microtar_llar.gox
+++ b/rxi/microtar/v0.1.0/microtar_llar.gox
@@ -2,7 +2,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 )
 
 const consumerSource = `#include <stdio.h>
@@ -74,12 +73,23 @@ onBuild ctx => {
 	os.mkdirAll(licenseDir, 0o755)!
 	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
 
-	flags := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-lmicrotar",
-	}
-	ctx.setMetadata strings.join(flags, " ")
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${exec_prefix}/lib
+includedir=$${prefix}/include
+
+Name: microtar
+Description: A lightweight tar library written in ANSI C
+Version: 0.1.0
+Libs: -L$${libdir} -lmicrotar
+Cflags: -I$${includedir}
+`
+	os.writeFile(filepath.join(pcDir, "microtar.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("microtar")!
 }
 
 onTest ctx => {
@@ -91,15 +101,11 @@ onTest ctx => {
 	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
 
 	binary := filepath.join(testDir, "consumer")
-	args := []string{
-		sourcePath,
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-lmicrotar",
-		"-o", binary,
-	}
-	exec "cc", args...
-	lastErr!
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "microtar.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("microtar")!), 0o644)!
+	cc! sourcePath, "@"+flagsFile, "-o", binary
 
 	if slices.contains(target.options["shared"], "ON") {
 		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
@@ -110,6 +116,5 @@ onTest ctx => {
 		}
 	}
 
-	exec binary
-	lastErr!
+	exec! binary
 }

--- a/rxi/microtar/versions.json
+++ b/rxi/microtar/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "rxi/microtar",
+  "deps": {}
+}


### PR DESCRIPTION
## Summary
- add the `rxi/microtar` LLAR Formula for upstream `v0.1.0`
- build and install the Conan Center CMake recipe output
- verify the installed header and library with a tar-writing consumer

## Source
- Conan Center snapshot: `ffe30df101afd4dc95aac2f14b25bf345e64d7be`
- upstream tag: `v0.1.0` (`956791770defa4d06696b30db276e88a09ad3538`)

## Validation
- `git diff --cached --check`
- Local Formula/CI tests intentionally not run per request.
