### PR TITLE
feat(cpp-optparse): add LLAR formula

### DIFF
--- a/weisslj/cpp-optparse/2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00/CMakeLists.txt
+++ b/weisslj/cpp-optparse/2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(cpp-optparse LANGUAGES CXX)
+
+include(GNUInstallDirs)
+
+add_library(OptionParser ${CPP_OPTPARSE_SRC_DIR}/OptionParser.cpp)
+set_target_properties(OptionParser PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+
+install(TARGETS OptionParser
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES ${CPP_OPTPARSE_SRC_DIR}/OptionParser.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/weisslj/cpp-optparse/2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00/cpp_optparse_llar.gox
+++ b/weisslj/cpp-optparse/2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00/cpp_optparse_llar.gox
@@ -1,0 +1,118 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <string>
+#include <vector>
+
+#include "OptionParser.h"
+
+using optparse::OptionParser;
+using namespace std;
+
+int main(int argc, char *argv[])
+{
+    OptionParser parser = OptionParser() .description("just an example");
+
+    parser.add_option("-f", "--file") .dest("filename")
+                      .help("write report to FILE") .metavar("FILE");
+    parser.add_option("-q", "--quiet")
+                      .action("store_false") .dest("verbose") .set_default("1")
+                      .help("don't print status messages to stdout");
+
+    optparse::Values options = parser.parse_args(argc, argv);
+    vector<string> args = parser.args();
+
+    if (options.get("verbose"))
+        cout << options["filename"] << endl;
+}
+`
+
+// Conan Center cci.20171104 pins weisslj/cpp-optparse to this untagged commit.
+id "weisslj/cpp-optparse"
+
+fromVer "2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+
+	cmakeLists := ctx.Proj.readFile("2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00/CMakeLists.txt")!
+	os.writeFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"), cmakeLists, 0o644)!
+
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CPP_OPTPARSE_SRC_DIR", ctx.SourceDir
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	metadata := []string{
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lOptionParser",
+	}
+	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
+		metadata <- "-lm"
+	}
+	ctx.setMetadata strings.join(metadata, " ")
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	testBuild := filepath.join(testDir, "_build")
+	sourcePath := filepath.join(testDir, "consumer.cpp")
+	binary := filepath.join(testBuild, "consumer")
+	os.mkdirAll(testBuild, 0o755)!
+	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
+
+	args := []string{
+		sourcePath,
+		"-I" + filepath.join(installDir, "include"),
+		"-L" + filepath.join(installDir, "lib"),
+		"-lOptionParser",
+	}
+	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
+		args <- "-lm"
+	}
+	args <- "-o"
+	args <- binary
+	exec "c++", args...
+	lastErr!
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec binary, "--help"
+	lastErr!
+}

--- a/weisslj/cpp-optparse/2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00/cppoptparse_llar.gox
+++ b/weisslj/cpp-optparse/2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00/cppoptparse_llar.gox
@@ -2,7 +2,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 )
 
 const consumerSource = `#include <string>
@@ -65,6 +64,8 @@ onBuild ctx => {
 	fPIC := slices.contains(target.options["fPIC"], "ON")
 	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
 	c.define "CPP_OPTPARSE_SRC_DIR", ctx.SourceDir
+	// pkgconfig.use searches the installed lib/pkgconfig directory.
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
 	c.defineBool "BUILD_SHARED_LIBS", shared
 	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
 	c.configure
@@ -75,15 +76,27 @@ onBuild ctx => {
 	os.mkdirAll(licenseDir, 0o755)!
 	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
 
-	metadata := []string{
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-lOptionParser",
-	}
+	libs := "-L$${libdir} -lOptionParser"
 	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
-		metadata <- "-lm"
+		libs += " -lm"
 	}
-	ctx.setMetadata strings.join(metadata, " ")
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: cpp-optparse
+Description: Python's excellent OptionParser in C++
+Version: 2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00
+Libs: ` + libs + `
+Cflags: -I$${includedir}
+`
+	os.writeFile(filepath.join(pcDir, "cpp-optparse.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("cpp-optparse")!
 }
 
 onTest ctx => {
@@ -95,24 +108,14 @@ onTest ctx => {
 	os.mkdirAll(testBuild, 0o755)!
 	os.writeFile(sourcePath, []byte(consumerSource), 0o644)!
 
-	args := []string{
-		sourcePath,
-		"-I" + filepath.join(installDir, "include"),
-		"-L" + filepath.join(installDir, "lib"),
-		"-lOptionParser",
-	}
-	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
-		args <- "-lm"
-	}
-	args <- "-o"
-	args <- binary
-	exec "c++", args...
-	lastErr!
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "cpp-optparse.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("cpp-optparse")!), 0o644)!
+	exec! "c++", sourcePath, "-o", binary, "@"+flagsFile
 
 	if slices.contains(target.options["shared"], "ON") {
 		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
 	}
-	exec binary, "--help"
-	lastErr!
+	exec! binary, "--help"
 }

--- a/weisslj/cpp-optparse/versions.json
+++ b/weisslj/cpp-optparse/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "weisslj/cpp-optparse",
+	"deps": {}
+}


### PR DESCRIPTION
## Summary

- add `weisslj/cpp-optparse` at Conan Center's pinned commit `2ec0b7aca9a692ff93017ed44ca9d13a8e7d4d00`
- translate the CCI CMake install flow and preserve `shared`/`fPIC` options
- add the upstream consumer check and platform-specific `libm` metadata

## Validation

- `git diff --check`
- local `llar test` not run per request
