### PR TITLE
ci: use idiomatic gsh syntax

### DIFF
--- a/.github/scripts/find_changed_modules.gsh
+++ b/.github/scripts/find_changed_modules.gsh
@@ -104,14 +104,12 @@ for module in changedModules {
 
 // TODO: When changed modules depend on each other, test only the leaf modules
 // in their dependency graph.
-modulesJSON := string(json.marshal(changedModules)!)
-hasModules := sprint(changedModules.len > 0)
+modulesJSON := json.marshal(changedModules)!
 
 outputFile := os.openFile($GITHUB_OUTPUT, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)!
 defer outputFile.close()
-fprintln! outputFile, "modules=${modulesJSON}"
-fprintln! outputFile, "has_modules=${hasModules}"
+fprintf! outputFile, "modules=%s\nhas_modules=%t\n", modulesJSON, changedModules.len > 0
 
 summaryFile := os.openFile($GITHUB_STEP_SUMMARY, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)!
 defer summaryFile.close()
-fprintln! summaryFile, "Changed modules: ${modulesJSON}"
+fprintf! summaryFile, "Changed modules: %s\n", modulesJSON

--- a/.github/scripts/find_changed_modules.gsh
+++ b/.github/scripts/find_changed_modules.gsh
@@ -1,6 +1,5 @@
 import (
 	"encoding/json"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -45,21 +44,18 @@ refName := $REF_NAME
 
 var diffBase string
 if eventName == "pull_request" {
-	capout => { git "merge-base", baseSHA, headSHA }
-	lastErr!
+	capout => { git! "merge-base", baseSHA, headSHA }
 	diffBase = output.trimSpace
 } else if refName == defaultBranch {
 	diffBase = baseSHA
 } else {
-	capout => { git "merge-base", "origin/"+defaultBranch, headSHA }
-	lastErr!
+	capout => { git! "merge-base", "origin/"+defaultBranch, headSHA }
 	diffBase = output.trimSpace
 }
 
 capout => {
-	git "diff", "--name-only", "--diff-filter=ACDMRT", "-z", diffBase, headSHA
+	git! "diff", "--name-only", "--diff-filter=ACDMRT", "-z", diffBase, headSHA
 }
-lastErr!
 
 var modules map[string]bool = {}
 var formulaDirs map[string]map[string]bool = {}
@@ -76,7 +72,7 @@ for changedPath in output.split("\x00") {
 		}
 		has := hasFormula(module)!
 		if has {
-			panic fmt.Sprintf("module %s is missing versions.json", module)
+			panic "module ${module} is missing versions.json"
 		}
 		continue
 	}
@@ -93,8 +89,7 @@ for changedPath in output.split("\x00") {
 	}
 }
 
-changedModules := []string([])
-changedModules <- [module for module, _ in modules]...
+changedModules := [module for module, _ in modules]
 sort.strings changedModules
 
 for module in changedModules {
@@ -102,18 +97,21 @@ for module in changedModules {
 	if len(dirs) > 1 {
 		changedDirs := [dir for dir, _ in dirs]
 		sort.strings changedDirs
-		panic fmt.Sprintf("module %s changes multiple Formula directories: %s; llar test cannot validate multiple fromVer ranges yet", module, changedDirs.join(", "))
+		changedDirsText := changedDirs.join(", ")
+		panic "module ${module} changes multiple Formula directories: ${changedDirsText}; llar test cannot validate multiple fromVer ranges yet"
 	}
 }
 
 // TODO: When changed modules depend on each other, test only the leaf modules
 // in their dependency graph.
-modulesJSON := json.marshal(changedModules)!
+modulesJSON := string(json.marshal(changedModules)!)
+hasModules := sprint(changedModules.len > 0)
 
 outputFile := os.openFile($GITHUB_OUTPUT, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)!
 defer outputFile.close()
-fmt.fprintf! outputFile, "modules=%s\nhas_modules=%t\n", modulesJSON, changedModules.len > 0
+fprintln! outputFile, "modules=${modulesJSON}"
+fprintln! outputFile, "has_modules=${hasModules}"
 
 summaryFile := os.openFile($GITHUB_STEP_SUMMARY, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)!
 defer summaryFile.close()
-fmt.fprintf! summaryFile, "Changed modules: %s\n", modulesJSON
+fprintln! summaryFile, "Changed modules: ${modulesJSON}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.after }}
           REF_NAME: ${{ github.ref_name }}
         run: |
-          go install -tags=linknamefix -ldflags="-checklinkname=0" github.com/goplus/ixgo/cmd/ixgo@v1.1.1
+          go install -tags=linknamefix -ldflags="-checklinkname=0" github.com/goplus/ixgo/cmd/ixgo@latest
           "$(go env GOPATH)/bin/ixgo" run .github/scripts/find_changed_modules.gsh
 
   test:


### PR DESCRIPTION
This PR simplifies changed Formula discovery with idiomatic gsh and XGo syntax.

The implementation includes:

- propagate Git command failures inside `capout` with `git!`
- construct `changedModules` directly with an XGo list comprehension
- use `${}` interpolation for panic messages
- use the builtin `fprintf!` without importing `fmt`
- install `ixgo@latest` for changed-module discovery
- allow an empty comprehension to serialize as `null` while `has_modules=false` remains the test-job gate

This keeps the discovery flow compact and lets CI consume current XGo/gsh syntax.