### PR TITLE
docs: require simple XGo formula syntax

### DIFF
--- a/.agents/skills/write-formula/SKILL.md
+++ b/.agents/skills/write-formula/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-formula
-description: Create, migrate, review, debug, and validate LLAR Formula modules, including versions.json, _llar.gox recipes, _cmp.gox comparators, dependency discovery, build matrices, gsh commands, CMake and Autotools builds, metadata, and consumer tests. Use for work in llarhub or another LLAR Formula store, especially when the Formula should use idiomatic XGo and gsh rather than Go-shaped boilerplate.
+description: Use when creating, migrating, reviewing, debugging, or validating LLAR Formula modules in llarhub or another Formula store, including versions.json, _llar.gox recipes, _cmp.gox comparators, dependency discovery, build matrices, gsh commands, CMake and Autotools builds, metadata, and consumer tests.
 ---
 
 # Write LLAR Formulas
@@ -73,22 +73,24 @@ LLAR's configured streams, working directory, and execution path.
   configuration.
 - Keep imports, types, fields, and classfile methods before the first top-level
   executable Formula statement.
-- Start the Formula filename stem with a lowercase ASCII letter, for example
-  `picobench_llar.gox`. Do not capitalize it from a repository or type name.
+- In llarhub, start the Formula filename stem with a lowercase ASCII letter,
+  for example `picobench_llar.gox`. Do not capitalize it from a repository or
+  type name even when LLAR accepts that spelling.
 - Use only callback signatures and APIs found in the resolved LLAR revision.
 - Never call generated `XGot_`, `Gopt_`, `Gops_`, `Gopx_`, `Gopo_`, or numbered
   overload names from Formula source.
 - Fail every required command or required error-returning operation. Branch on
   an error only when its distinct outcomes have verified meaning.
-- Put `!` on a required gsh command itself, including inside `capout`; do not
-  follow it with a separate `lastErr!` when `command! args` has the same
-  semantics. Read `lastErr` only when command failure changes control flow.
-- Use unqualified XGo format builtins such as `fprintf!`, `sprintf`, and
-  `errorf`; do not import or prefix `fmt` only to call their Go equivalents.
-  Prefer `${expr}` interpolation when constructing a plain string.
-- Assign a direct list comprehension when it is the complete transformation.
-  Do not create an empty slice and append the same comprehension unless a
-  proved empty-value representation requires it.
+- Put `!` on a required error-returning outer call, including a gsh command
+  inside `capout`. Keep parentheses when the result is consumed. Do not add `!`
+  to a void helper that fails internally, or use `lastErr!` when direct `!` has
+  the required semantics; read `lastErr` only for verified control flow.
+- Use unqualified XGo format builtins such as `fprintf!`, `fprintln!`,
+  `sprintf`, and `errorf`; do not import or prefix `fmt` only to call their Go
+  equivalents.
+  Prefer `${expr}` only when the expression has a verified XGo string
+  conversion. Use a format builtin for bool, `[]byte`, formatting directives,
+  or any value the active ixgo cannot interpolate.
 - Keep commands inside Formula lifecycle hooks; top-level Formula statements
   register configuration and callbacks.
 - Derive metadata from the installed consumer interface and verify it with a

--- a/.agents/skills/write-formula/SKILL.md
+++ b/.agents/skills/write-formula/SKILL.md
@@ -7,7 +7,8 @@ description: Create, migrate, review, debug, and validate LLAR Formula modules, 
 
 Treat a Formula as an XGo classfile that composes LLAR's Formula contract with
 the gsh execution surface. Write idiomatic XGo/gsh source, not Go code with a
-`.gox` suffix.
+`.gox` suffix. Prefer the shortest verified XGo/gsh form that preserves the
+required semantics.
 
 ## Establish The Contract
 
@@ -42,8 +43,9 @@ documentation as a substitute for that source.
 5. Implement the smallest Formula that preserves the verified installed
    consumer interface. Prefer the LLAR build-system helper matching upstream;
    use inherited gsh commands for verified steps the helper does not own.
-6. Perform an XGo style pass. Prefer the verified XGo/gsh forms from the style
-   reference wherever they make the same logic shorter and clearer.
+6. Perform an XGo style pass. Replace redundant setup, error checks, package
+   qualifiers, and temporary collections with the shorter verified XGo/gsh
+   form from the style reference.
 7. Compile through LLAR's actual ixgo path, then run the target repository's
    Formula validation for exact and representative versions, options, and
    cache-hit tests required by the change.
@@ -78,6 +80,15 @@ LLAR's configured streams, working directory, and execution path.
   overload names from Formula source.
 - Fail every required command or required error-returning operation. Branch on
   an error only when its distinct outcomes have verified meaning.
+- Put `!` on a required gsh command itself, including inside `capout`; do not
+  follow it with a separate `lastErr!` when `command! args` has the same
+  semantics. Read `lastErr` only when command failure changes control flow.
+- Use unqualified XGo format builtins such as `fprintf!`, `sprintf`, and
+  `errorf`; do not import or prefix `fmt` only to call their Go equivalents.
+  Prefer `${expr}` interpolation when constructing a plain string.
+- Assign a direct list comprehension when it is the complete transformation.
+  Do not create an empty slice and append the same comprehension unless a
+  proved empty-value representation requires it.
 - Keep commands inside Formula lifecycle hooks; top-level Formula statements
   register configuration and callbacks.
 - Derive metadata from the installed consumer interface and verify it with a

--- a/.agents/skills/write-formula/SKILL.md
+++ b/.agents/skills/write-formula/SKILL.md
@@ -7,7 +7,7 @@ description: Use when creating, migrating, reviewing, debugging, or validating L
 
 Treat a Formula as an XGo classfile that composes LLAR's Formula contract with
 the gsh execution surface. Write idiomatic XGo/gsh source, not Go code with a
-`.gox` suffix. Prefer the shortest verified XGo/gsh form that preserves the
+`.gox` suffix. Use the simplest verified XGo/gsh form that preserves the
 required semantics.
 
 ## Establish The Contract
@@ -44,7 +44,7 @@ documentation as a substitute for that source.
    consumer interface. Prefer the LLAR build-system helper matching upstream;
    use inherited gsh commands for verified steps the helper does not own.
 6. Perform an XGo style pass. Replace redundant setup, error checks, package
-   qualifiers, and temporary collections with the shorter verified XGo/gsh
+   qualifiers, and temporary collections with the simpler verified XGo/gsh
    form from the style reference.
 7. Compile through LLAR's actual ixgo path, then run the target repository's
    Formula validation for exact and representative versions, options, and

--- a/.agents/skills/write-formula/references/contract-discovery.md
+++ b/.agents/skills/write-formula/references/contract-discovery.md
@@ -37,7 +37,11 @@ Read the complete declarations found by these searches. Establish:
 - the generated entry contract;
 - each top-level Formula method and callback signature;
 - promoted fields and methods available inside callbacks;
-- the ownership and error behavior of build and test context values.
+- the ownership and error behavior of source, build, and test context values.
+
+Also locate the Formula and comparator selection code. Confirm suffix matching,
+`fromVer` extraction and ordering, duplicate-threshold behavior, comparator
+discovery, and cache keys instead of inferring them from the directory layout.
 
 Do not infer an XGo surface from a generated Go name. Resolve lowercase aliases,
 auto-properties, overloads, and template receiver methods using the selected
@@ -92,6 +96,11 @@ Read the selected LLAR revision's `go.mod`. Record the exact versions of:
 - `github.com/goplus/gogen`;
 - `github.com/goplus/mod`;
 - the module providing `gsh.App`.
+
+Treat a Formula store's standalone XGo or gsh script toolchain separately. For
+example, llarhub may run a CI helper with `ixgo@latest` while compiling Formulas
+through the ixgo version pinned by LLAR. Acceptance by the first does not prove
+acceptance by the second.
 
 Read the matching module-cache source and documentation when a syntax or
 classfile rule matters. The Formula is compiled through LLAR's ixgo embedding

--- a/.agents/skills/write-formula/references/formula-semantics.md
+++ b/.agents/skills/write-formula/references/formula-semantics.md
@@ -25,8 +25,9 @@ the comparator's input rules and the complete set must have the intended total
 order. In particular, use a semantic-version comparator only when every tag is
 valid semantic-version syntax.
 
-Start every `_llar.gox` filename stem with a lowercase ASCII letter. For
-example, use `picobench_llar.gox`, not `Picobench_llar.gox`.
+In llarhub, start every `_llar.gox` filename stem with a lowercase ASCII letter.
+For example, use `picobench_llar.gox`, not `Picobench_llar.gox`; do not present
+this convention as an LLAR parser limit.
 
 ## Upstream Investigation
 
@@ -53,6 +54,11 @@ When dependency versions vary inside a Formula range and upstream records them
 in a stable machine-readable source file, discover them from the requested tag
 through the active Formula dependency hook. Parse structured formats with a
 structured parser.
+
+Resolve source ownership separately for every hook. Do not assume a project
+filesystem exposed during dependency discovery refers to the same source as a
+build context. During build or test, use the upstream source directory exposed
+by the active context unless that LLAR revision proves another API owns it.
 
 Use `versions.json` according to the selected LLAR loader's actual reconciliation
 rules. Treat static dependency entries as verified conservative data, not as a
@@ -86,7 +92,9 @@ Install the complete public result into the current module's output directory.
 Do not depend on a build scratch path after the build callback returns.
 
 For an unsupported build system, use gsh commands with separate arguments and
-explicit failure propagation. Add a shell only when the verified upstream step
+explicit failure propagation. Call active CMake or Autotools helper methods
+according to their real return contract; do not add `!` to a void helper that
+already panics on failure. Add a shell only when the verified upstream step
 requires shell grammar.
 
 ## Metadata

--- a/.agents/skills/write-formula/references/xgo-gsh-style.md
+++ b/.agents/skills/write-formula/references/xgo-gsh-style.md
@@ -35,7 +35,7 @@ rules below.
 
 ## XGo-First Formula Style
 
-Prefer the shortest verified XGo form whenever it expresses the same behavior
+Use the simplest verified XGo form whenever it expresses the same behavior
 directly:
 
 - Write callback values as lambdas.

--- a/.agents/skills/write-formula/references/xgo-gsh-style.md
+++ b/.agents/skills/write-formula/references/xgo-gsh-style.md
@@ -64,6 +64,20 @@ directly:
 - Use `.len` for strings and slices. Use `len(mapping)` for maps; `mapping.len`
   is a lookup of the key `"len"`, not the map length.
 
+### String Construction
+
+- Prefer interpolation for short text containing values with a verified XGo
+  string conversion, for example `"module=${module}"`.
+- Use `+` only when both operands are strings. Convert numeric values explicitly
+  with `.string`, for example `"age = " + age.string`.
+- Use `values.join(separator)` when combining an existing string slice. When
+  assembling many parts, collect the strings and join them instead of folding
+  repeated `+` operations through a loop.
+- Use `sprintf` or `fprintf` for format directives and values that the active
+  ixgo cannot interpolate, such as `bool` or `[]byte`.
+- Do not call compiler implementation helpers such as `stringutil.Concat` from
+  a Formula; resolve the supported syntax against LLAR's active ixgo toolchain.
+
 For example:
 
 ```xgo

--- a/.agents/skills/write-formula/references/xgo-gsh-style.md
+++ b/.agents/skills/write-formula/references/xgo-gsh-style.md
@@ -9,7 +9,8 @@ Formula. It is an executable style sample, not a Formula API reference.
 Reuse applicable idioms demonstrated there:
 
 - lowercase-first-letter calls such as `filepath.join` and `json.marshal`;
-- auto-properties such as `entry.isDir`, `output.trimSpace`, and `values.len`;
+- auto-properties such as `entry.isDir`, `output.trimSpace`, and the string or
+  slice property `values.len`;
 - XGo loops such as `for value in values`;
 - lambdas such as `(_, entry, err) => { ... }`;
 - direct list comprehensions for complete collection transformations;
@@ -46,12 +47,22 @@ directly:
   equivalent operation supported by the active XGo version.
 - Use a comprehension when it is a direct filter or transform, not when it
   hides stateful control flow or changes empty-value semantics.
-- Use command-style calls and `!` when every failure must abort the current
-  panic boundary.
+- Use `{value for value in values if condition}` for the first matching value
+  and optional `value, ok` result. Use `{for value in values if condition}` for
+  an existence check when first-match or any-match semantics are intended. Do
+  not hide stateful actions in either form.
+- Use command style for the outermost side-effect call. Attach `!` before its
+  arguments when it must succeed, for example `format.node! buf, fset, file`.
+  Keep parentheses for nested calls and calls whose result is consumed, for
+  example `value := parse(input)!`.
 - Use unqualified XGo builtins instead of a `fmt.` prefix. Prefer `${expr}` to
-  `sprintf` when no formatting directive is needed.
+  `sprintf` only when the expression has a verified XGo string conversion.
+  Bool, `[]byte`, formatting directives, and unsupported conversions require
+  `sprintf`, `fprintf`, or separate output arguments.
 - When an interpolation expression needs a string literal, use a raw string
   inside the braces, for example `${values.join(`, `)}`.
+- Use `.len` for strings and slices. Use `len(mapping)` for maps; `mapping.len`
+  is a lookup of the key `"len"`, not the map length.
 
 For example:
 
@@ -77,9 +88,16 @@ type conversions solely to demonstrate language features.
 
 Match syntax to semantics:
 
-- Use `!` for a required operation whose only valid result is success.
-- For a required gsh command, attach `!` to the command itself. Inside a
-  capture block, write `capout => { command! args }`.
+- Use `!` for a required error-returning operation whose only valid result is
+  success. Do not attach it to a void LLAR helper that already panics on failure.
+- For a required error-returning side-effect call, attach `!` to the outer
+  command-style call.
+  Inside a capture block, write `capout => { command! args }`. When a result is
+  consumed, keep expression syntax such as `value := operation(args)!`.
+- Use `?` only in a function that returns an error. When the resolved lifecycle
+  callback returns no error, use `!` or inspect the error there. Use `?:` only
+  for a source-backed default, not as a defensive fallback for a failed build
+  operation.
 - Inspect an error explicitly when absence, unsupported input, or another error
   class changes the Formula's behavior.
 - Accumulate errors only when the active Formula contract exposes an error list
@@ -101,12 +119,17 @@ does not turn command strings into a POSIX shell language.
   Do not wrap such a command in `exec` merely because it has flags or multiple
   arguments.
 - Use `exec` only for paths, names containing punctuation, keywords, collisions,
-  or explicit environment overlays.
+  or explicit environment overlays. Prefer the map overload for a per-command
+  overlay, for example
+  `exec! {"CC": compiler}, "./configure", "--disable-shared"`.
 - Use `capout` only when the Formula consumes stdout. Put `!` on a required
-  command inside the capture block before reading `output`.
+  command inside the capture block before reading `output`; stderr is not part
+  of the captured value.
 - Use the explicit argument form when arguments must remain separate.
-- Treat the one-string `exec` form as field splitting plus environment
-  expansion unless the selected gsh source proves otherwise.
+- Treat the one-string `exec` form as whitespace splitting followed by
+  environment expansion, without resplitting, unless the selected gsh source
+  proves otherwise. Quotes do not group fields under this implementation, and
+  prefix overlays do not affect later `$NAME` expansion in the same string.
 - Invoke a verified shell explicitly when a build step truly requires pipes,
   redirection, globbing, command substitution, or shell operators.
 
@@ -124,5 +147,5 @@ Using a Go package does not make Formula source Go-first. XGo is designed to
 call Go libraries. Use structured Go APIs through XGo spelling for JSON, YAML,
 filesystem traversal, archive formats, and source manifest parsing instead of
 reimplementing parsers with shell text processing. XGo exposes common `fmt`
-operations as builtins; use `fprintf!`, `sprintf`, `errorf`, and related forms
-without importing or qualifying `fmt`.
+operations as builtins; use `fprintf!`, `fprintln!`, `sprintf`, `errorf`, and
+related forms without importing or qualifying `fmt`.

--- a/.agents/skills/write-formula/references/xgo-gsh-style.md
+++ b/.agents/skills/write-formula/references/xgo-gsh-style.md
@@ -12,12 +12,16 @@ Reuse applicable idioms demonstrated there:
 - auto-properties such as `entry.isDir`, `output.trimSpace`, and `values.len`;
 - XGo loops such as `for value in values`;
 - lambdas such as `(_, entry, err) => { ... }`;
-- list comprehensions for real collection transformations;
+- direct list comprehensions for complete collection transformations;
 - typed empty collections when the empty value's type or encoded form matters;
-- `<-` for slice append;
+- `<-` only for genuine incremental slice append;
 - `expr!` for operations that must succeed;
 - `$NAME` for environment values exposed by the gsh class;
-- direct commands, `capout`, `lastErr!`, and `output` for external processes.
+- `command! args`, `capout => { command! args }`, and `output` for required
+  external processes;
+- `${expr}` for plain string construction and panic messages;
+- unqualified format builtins such as `fprintf!` when a format string is
+  clearer than interpolation.
 
 Do not copy its Git diff policy, GitHub output handling, filesystem rules, or
 top-level execution shape into a Formula. A `.gsh` project executes its script
@@ -30,7 +34,8 @@ rules below.
 
 ## XGo-First Formula Style
 
-Prefer verified XGo forms whenever they express the same behavior directly:
+Prefer the shortest verified XGo form whenever it expresses the same behavior
+directly:
 
 - Write callback values as lambdas.
 - Omit parentheses for a side-effect-only statement call.
@@ -41,7 +46,23 @@ Prefer verified XGo forms whenever they express the same behavior directly:
   equivalent operation supported by the active XGo version.
 - Use a comprehension when it is a direct filter or transform, not when it
   hides stateful control flow or changes empty-value semantics.
-- Use `operation()!` when every failure must abort the current panic boundary.
+- Use command-style calls and `!` when every failure must abort the current
+  panic boundary.
+- Use unqualified XGo builtins instead of a `fmt.` prefix. Prefer `${expr}` to
+  `sprintf` when no formatting directive is needed.
+- When an interpolation expression needs a string literal, use a raw string
+  inside the braces, for example `${values.join(`, `)}`.
+
+For example:
+
+```xgo
+capout => { git! "merge-base", baseSHA, headSHA }
+diffBase := output.trimSpace
+
+changedModules := [module for module, _ in modules]
+panic "invalid module ${module}"
+fprintf! outputFile, "modules=%s\n", modulesJSON
+```
 
 After drafting, review Go-shaped candidates such as unused-index `range` loops,
 manual panic-on-error blocks, uppercase imported calls, and parenthesized
@@ -57,11 +78,15 @@ type conversions solely to demonstrate language features.
 Match syntax to semantics:
 
 - Use `!` for a required operation whose only valid result is success.
+- For a required gsh command, attach `!` to the command itself. Inside a
+  capture block, write `capout => { command! args }`.
 - Inspect an error explicitly when absence, unsupported input, or another error
   class changes the Formula's behavior.
 - Accumulate errors only when the active Formula contract exposes an error list
   and the operations are genuinely independent.
-- Check gsh command status immediately; the next command replaces `lastErr`.
+- Read `lastErr` only when command failure is an expected value that selects a
+  verified branch. Do not use `lastErr!` after a required command when the
+  command-style `!` form is available.
 
 Do not replace meaningful error classification with `!`. Do not expand a
 required operation into repetitive `if err != nil { panic err }` code.
@@ -77,8 +102,8 @@ does not turn command strings into a POSIX shell language.
   arguments.
 - Use `exec` only for paths, names containing punctuation, keywords, collisions,
   or explicit environment overlays.
-- Use `capout` only when the Formula consumes stdout; validate the command before
-  reading `output`.
+- Use `capout` only when the Formula consumes stdout. Put `!` on a required
+  command inside the capture block before reading `output`.
 - Use the explicit argument form when arguments must remain separate.
 - Treat the one-string `exec` form as field splitting plus environment
   expansion unless the selected gsh source proves otherwise.
@@ -98,4 +123,6 @@ command and compile through the active ixgo path.
 Using a Go package does not make Formula source Go-first. XGo is designed to
 call Go libraries. Use structured Go APIs through XGo spelling for JSON, YAML,
 filesystem traversal, archive formats, and source manifest parsing instead of
-reimplementing parsers with shell text processing.
+reimplementing parsers with shell text processing. XGo exposes common `fmt`
+operations as builtins; use `fprintf!`, `sprintf`, `errorf`, and related forms
+without importing or qualifying `fmt`.

--- a/.agents/skills/write-formula/references/xgo-gsh-style.md
+++ b/.agents/skills/write-formula/references/xgo-gsh-style.md
@@ -38,7 +38,8 @@ rules below.
 Use the simplest verified XGo form whenever it expresses the same behavior
 directly:
 
-- Write callback values as lambdas.
+- Write callback values as lambdas when the target API supplies an expected
+  function type; an untyped standalone lambda has no context for inference.
 - Omit parentheses for a side-effect-only statement call.
 - Use lowercase aliases for exported Go functions and methods.
 - Use auto-properties for zero-argument getters.
@@ -77,6 +78,29 @@ directly:
   ixgo cannot interpolate, such as `bool` or `[]byte`.
 - Do not call compiler implementation helpers such as `stringutil.Concat` from
   a Formula; resolve the supported syntax against LLAR's active ixgo toolchain.
+
+### Collections And Control Flow
+
+- Use inferred list literals `[value1, value2]` and map literals
+  `{"key": value}` for non-empty collections. Give an empty collection an
+  explicit slice or map type, or use `make`, when later assignment or encoding
+  depends on its concrete element types.
+- Use list and map comprehensions for direct transforms and filters, for
+  example `[f(value) for value in values if keep(value)]` and
+  `{key(value): value for value in values}`. Keep side effects and multi-step
+  logic in a loop.
+- Use `for value in values`, `for key, value in mapping`, and a trailing `if`
+  on a `for` loop when the body performs filtered side effects. Use
+  `for i in start:end:step` for a numeric sequence; retain a C-style loop only
+  when its mutable state is the clearest form.
+- Use `<-` only for genuine incremental slice append. Use `append` when the
+  returned slice is the value being composed or passed onward.
+- Compare a map, slice, or pointer with `nil` only when the producing API can
+  return nil. A nil map cannot accept entry assignments; initialize it before
+  writing entries, and do not add nil checks as generic defensive code.
+- Use comma-ok map access when missing data has a verified meaning, for example
+  `value, ok := mapping[key]`; do not use it to hide a required configuration
+  error.
 
 For example:
 
@@ -138,7 +162,9 @@ does not turn command strings into a POSIX shell language.
   `exec! {"CC": compiler}, "./configure", "--disable-shared"`.
 - Use `capout` only when the Formula consumes stdout. Put `!` on a required
   command inside the capture block before reading `output`; stderr is not part
-  of the captured value.
+  of the captured value. Under LLAR's broker, this captures gsh child-command
+  stdout; it does not make arbitrary XGo `echo` or `println` output part of
+  `output`.
 - Use the explicit argument form when arguments must remain separate.
 - Treat the one-string `exec` form as whitespace splitting followed by
   environment expansion, without resplitting, unless the selected gsh source
@@ -163,3 +189,18 @@ filesystem traversal, archive formats, and source manifest parsing instead of
 reimplementing parsers with shell text processing. XGo exposes common `fmt`
 operations as builtins; use `fprintf!`, `fprintln!`, `sprintf`, `errorf`, and
 related forms without importing or qualifying `fmt`.
+
+Imports remain explicit unless the resolved LLAR `gox.mod` registers an
+auto-import. In the pinned Formula contract, `cmake` and `autotools` are
+registered helpers; ordinary packages such as `os`, `strings`, `slices`, and
+`encoding/json` still require an import. Resolve this list against the active
+LLAR revision instead of assuming a helper is globally available.
+
+Use lowercase XGo aliases and auto-properties only for verified exported Go
+functions and zero-argument getters, such as `filepath.join`, `ctx.outputDir`,
+and `entry.isDir`. Keep parentheses for nested calls and calls whose result is
+consumed; omit them for side-effect-only command statements. LLAR build
+helpers whose methods return no error, such as
+`c.configure`, `c.build`, `c.install`, and `pkgconfig.use`, are called directly;
+use `!` for separate gsh or Go operations that return an error, such as
+`pkgconfig.lookup`.

--- a/.claude/skills/write-formula/SKILL.md
+++ b/.claude/skills/write-formula/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-formula
-description: Create, migrate, review, debug, and validate LLAR Formula modules, including versions.json, _llar.gox recipes, _cmp.gox comparators, dependency discovery, build matrices, gsh commands, CMake and Autotools builds, metadata, and consumer tests. Use for work in llarhub or another LLAR Formula store, especially when the Formula should use idiomatic XGo and gsh rather than Go-shaped boilerplate.
+description: Use when creating, migrating, reviewing, debugging, or validating LLAR Formula modules in llarhub or another Formula store, including versions.json, _llar.gox recipes, _cmp.gox comparators, dependency discovery, build matrices, gsh commands, CMake and Autotools builds, metadata, and consumer tests.
 argument-hint: "[owner/repo] [version]"
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit, WebFetch
 ---
@@ -75,22 +75,24 @@ LLAR's configured streams, working directory, and execution path.
   configuration.
 - Keep imports, types, fields, and classfile methods before the first top-level
   executable Formula statement.
-- Start the Formula filename stem with a lowercase ASCII letter, for example
-  `picobench_llar.gox`. Do not capitalize it from a repository or type name.
+- In llarhub, start the Formula filename stem with a lowercase ASCII letter,
+  for example `picobench_llar.gox`. Do not capitalize it from a repository or
+  type name even when LLAR accepts that spelling.
 - Use only callback signatures and APIs found in the resolved LLAR revision.
 - Never call generated `XGot_`, `Gopt_`, `Gops_`, `Gopx_`, `Gopo_`, or numbered
   overload names from Formula source.
 - Fail every required command or required error-returning operation. Branch on
   an error only when its distinct outcomes have verified meaning.
-- Put `!` on a required gsh command itself, including inside `capout`; do not
-  follow it with a separate `lastErr!` when `command! args` has the same
-  semantics. Read `lastErr` only when command failure changes control flow.
-- Use unqualified XGo format builtins such as `fprintf!`, `sprintf`, and
-  `errorf`; do not import or prefix `fmt` only to call their Go equivalents.
-  Prefer `${expr}` interpolation when constructing a plain string.
-- Assign a direct list comprehension when it is the complete transformation.
-  Do not create an empty slice and append the same comprehension unless a
-  proved empty-value representation requires it.
+- Put `!` on a required error-returning outer call, including a gsh command
+  inside `capout`. Keep parentheses when the result is consumed. Do not add `!`
+  to a void helper that fails internally, or use `lastErr!` when direct `!` has
+  the required semantics; read `lastErr` only for verified control flow.
+- Use unqualified XGo format builtins such as `fprintf!`, `fprintln!`,
+  `sprintf`, and `errorf`; do not import or prefix `fmt` only to call their Go
+  equivalents.
+  Prefer `${expr}` only when the expression has a verified XGo string
+  conversion. Use a format builtin for bool, `[]byte`, formatting directives,
+  or any value the active ixgo cannot interpolate.
 - Keep commands inside Formula lifecycle hooks; top-level Formula statements
   register configuration and callbacks.
 - Derive metadata from the installed consumer interface and verify it with a

--- a/.claude/skills/write-formula/SKILL.md
+++ b/.claude/skills/write-formula/SKILL.md
@@ -9,7 +9,8 @@ allowed-tools: Read, Grep, Glob, Bash, Write, Edit, WebFetch
 
 Treat a Formula as an XGo classfile that composes LLAR's Formula contract with
 the gsh execution surface. Write idiomatic XGo/gsh source, not Go code with a
-`.gox` suffix.
+`.gox` suffix. Prefer the shortest verified XGo/gsh form that preserves the
+required semantics.
 
 ## Establish The Contract
 
@@ -44,8 +45,9 @@ documentation as a substitute for that source.
 5. Implement the smallest Formula that preserves the verified installed
    consumer interface. Prefer the LLAR build-system helper matching upstream;
    use inherited gsh commands for verified steps the helper does not own.
-6. Perform an XGo style pass. Prefer the verified XGo/gsh forms from the style
-   reference wherever they make the same logic shorter and clearer.
+6. Perform an XGo style pass. Replace redundant setup, error checks, package
+   qualifiers, and temporary collections with the shorter verified XGo/gsh
+   form from the style reference.
 7. Compile through LLAR's actual ixgo path, then run the target repository's
    Formula validation for exact and representative versions, options, and
    cache-hit tests required by the change.
@@ -80,6 +82,15 @@ LLAR's configured streams, working directory, and execution path.
   overload names from Formula source.
 - Fail every required command or required error-returning operation. Branch on
   an error only when its distinct outcomes have verified meaning.
+- Put `!` on a required gsh command itself, including inside `capout`; do not
+  follow it with a separate `lastErr!` when `command! args` has the same
+  semantics. Read `lastErr` only when command failure changes control flow.
+- Use unqualified XGo format builtins such as `fprintf!`, `sprintf`, and
+  `errorf`; do not import or prefix `fmt` only to call their Go equivalents.
+  Prefer `${expr}` interpolation when constructing a plain string.
+- Assign a direct list comprehension when it is the complete transformation.
+  Do not create an empty slice and append the same comprehension unless a
+  proved empty-value representation requires it.
 - Keep commands inside Formula lifecycle hooks; top-level Formula statements
   register configuration and callbacks.
 - Derive metadata from the installed consumer interface and verify it with a

--- a/.claude/skills/write-formula/SKILL.md
+++ b/.claude/skills/write-formula/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Grep, Glob, Bash, Write, Edit, WebFetch
 
 Treat a Formula as an XGo classfile that composes LLAR's Formula contract with
 the gsh execution surface. Write idiomatic XGo/gsh source, not Go code with a
-`.gox` suffix. Prefer the shortest verified XGo/gsh form that preserves the
+`.gox` suffix. Use the simplest verified XGo/gsh form that preserves the
 required semantics.
 
 ## Establish The Contract
@@ -46,7 +46,7 @@ documentation as a substitute for that source.
    consumer interface. Prefer the LLAR build-system helper matching upstream;
    use inherited gsh commands for verified steps the helper does not own.
 6. Perform an XGo style pass. Replace redundant setup, error checks, package
-   qualifiers, and temporary collections with the shorter verified XGo/gsh
+   qualifiers, and temporary collections with the simpler verified XGo/gsh
    form from the style reference.
 7. Compile through LLAR's actual ixgo path, then run the target repository's
    Formula validation for exact and representative versions, options, and

--- a/.claude/skills/write-formula/references/contract-discovery.md
+++ b/.claude/skills/write-formula/references/contract-discovery.md
@@ -37,7 +37,11 @@ Read the complete declarations found by these searches. Establish:
 - the generated entry contract;
 - each top-level Formula method and callback signature;
 - promoted fields and methods available inside callbacks;
-- the ownership and error behavior of build and test context values.
+- the ownership and error behavior of source, build, and test context values.
+
+Also locate the Formula and comparator selection code. Confirm suffix matching,
+`fromVer` extraction and ordering, duplicate-threshold behavior, comparator
+discovery, and cache keys instead of inferring them from the directory layout.
 
 Do not infer an XGo surface from a generated Go name. Resolve lowercase aliases,
 auto-properties, overloads, and template receiver methods using the selected
@@ -92,6 +96,11 @@ Read the selected LLAR revision's `go.mod`. Record the exact versions of:
 - `github.com/goplus/gogen`;
 - `github.com/goplus/mod`;
 - the module providing `gsh.App`.
+
+Treat a Formula store's standalone XGo or gsh script toolchain separately. For
+example, llarhub may run a CI helper with `ixgo@latest` while compiling Formulas
+through the ixgo version pinned by LLAR. Acceptance by the first does not prove
+acceptance by the second.
 
 Read the matching module-cache source and documentation when a syntax or
 classfile rule matters. The Formula is compiled through LLAR's ixgo embedding

--- a/.claude/skills/write-formula/references/formula-semantics.md
+++ b/.claude/skills/write-formula/references/formula-semantics.md
@@ -25,8 +25,9 @@ the comparator's input rules and the complete set must have the intended total
 order. In particular, use a semantic-version comparator only when every tag is
 valid semantic-version syntax.
 
-Start every `_llar.gox` filename stem with a lowercase ASCII letter. For
-example, use `picobench_llar.gox`, not `Picobench_llar.gox`.
+In llarhub, start every `_llar.gox` filename stem with a lowercase ASCII letter.
+For example, use `picobench_llar.gox`, not `Picobench_llar.gox`; do not present
+this convention as an LLAR parser limit.
 
 ## Upstream Investigation
 
@@ -53,6 +54,11 @@ When dependency versions vary inside a Formula range and upstream records them
 in a stable machine-readable source file, discover them from the requested tag
 through the active Formula dependency hook. Parse structured formats with a
 structured parser.
+
+Resolve source ownership separately for every hook. Do not assume a project
+filesystem exposed during dependency discovery refers to the same source as a
+build context. During build or test, use the upstream source directory exposed
+by the active context unless that LLAR revision proves another API owns it.
 
 Use `versions.json` according to the selected LLAR loader's actual reconciliation
 rules. Treat static dependency entries as verified conservative data, not as a
@@ -86,7 +92,9 @@ Install the complete public result into the current module's output directory.
 Do not depend on a build scratch path after the build callback returns.
 
 For an unsupported build system, use gsh commands with separate arguments and
-explicit failure propagation. Add a shell only when the verified upstream step
+explicit failure propagation. Call active CMake or Autotools helper methods
+according to their real return contract; do not add `!` to a void helper that
+already panics on failure. Add a shell only when the verified upstream step
 requires shell grammar.
 
 ## Metadata

--- a/.claude/skills/write-formula/references/xgo-gsh-style.md
+++ b/.claude/skills/write-formula/references/xgo-gsh-style.md
@@ -35,7 +35,7 @@ rules below.
 
 ## XGo-First Formula Style
 
-Prefer the shortest verified XGo form whenever it expresses the same behavior
+Use the simplest verified XGo form whenever it expresses the same behavior
 directly:
 
 - Write callback values as lambdas.

--- a/.claude/skills/write-formula/references/xgo-gsh-style.md
+++ b/.claude/skills/write-formula/references/xgo-gsh-style.md
@@ -64,6 +64,20 @@ directly:
 - Use `.len` for strings and slices. Use `len(mapping)` for maps; `mapping.len`
   is a lookup of the key `"len"`, not the map length.
 
+### String Construction
+
+- Prefer interpolation for short text containing values with a verified XGo
+  string conversion, for example `"module=${module}"`.
+- Use `+` only when both operands are strings. Convert numeric values explicitly
+  with `.string`, for example `"age = " + age.string`.
+- Use `values.join(separator)` when combining an existing string slice. When
+  assembling many parts, collect the strings and join them instead of folding
+  repeated `+` operations through a loop.
+- Use `sprintf` or `fprintf` for format directives and values that the active
+  ixgo cannot interpolate, such as `bool` or `[]byte`.
+- Do not call compiler implementation helpers such as `stringutil.Concat` from
+  a Formula; resolve the supported syntax against LLAR's active ixgo toolchain.
+
 For example:
 
 ```xgo

--- a/.claude/skills/write-formula/references/xgo-gsh-style.md
+++ b/.claude/skills/write-formula/references/xgo-gsh-style.md
@@ -9,7 +9,8 @@ Formula. It is an executable style sample, not a Formula API reference.
 Reuse applicable idioms demonstrated there:
 
 - lowercase-first-letter calls such as `filepath.join` and `json.marshal`;
-- auto-properties such as `entry.isDir`, `output.trimSpace`, and `values.len`;
+- auto-properties such as `entry.isDir`, `output.trimSpace`, and the string or
+  slice property `values.len`;
 - XGo loops such as `for value in values`;
 - lambdas such as `(_, entry, err) => { ... }`;
 - direct list comprehensions for complete collection transformations;
@@ -46,12 +47,22 @@ directly:
   equivalent operation supported by the active XGo version.
 - Use a comprehension when it is a direct filter or transform, not when it
   hides stateful control flow or changes empty-value semantics.
-- Use command-style calls and `!` when every failure must abort the current
-  panic boundary.
+- Use `{value for value in values if condition}` for the first matching value
+  and optional `value, ok` result. Use `{for value in values if condition}` for
+  an existence check when first-match or any-match semantics are intended. Do
+  not hide stateful actions in either form.
+- Use command style for the outermost side-effect call. Attach `!` before its
+  arguments when it must succeed, for example `format.node! buf, fset, file`.
+  Keep parentheses for nested calls and calls whose result is consumed, for
+  example `value := parse(input)!`.
 - Use unqualified XGo builtins instead of a `fmt.` prefix. Prefer `${expr}` to
-  `sprintf` when no formatting directive is needed.
+  `sprintf` only when the expression has a verified XGo string conversion.
+  Bool, `[]byte`, formatting directives, and unsupported conversions require
+  `sprintf`, `fprintf`, or separate output arguments.
 - When an interpolation expression needs a string literal, use a raw string
   inside the braces, for example `${values.join(`, `)}`.
+- Use `.len` for strings and slices. Use `len(mapping)` for maps; `mapping.len`
+  is a lookup of the key `"len"`, not the map length.
 
 For example:
 
@@ -77,9 +88,16 @@ type conversions solely to demonstrate language features.
 
 Match syntax to semantics:
 
-- Use `!` for a required operation whose only valid result is success.
-- For a required gsh command, attach `!` to the command itself. Inside a
-  capture block, write `capout => { command! args }`.
+- Use `!` for a required error-returning operation whose only valid result is
+  success. Do not attach it to a void LLAR helper that already panics on failure.
+- For a required error-returning side-effect call, attach `!` to the outer
+  command-style call.
+  Inside a capture block, write `capout => { command! args }`. When a result is
+  consumed, keep expression syntax such as `value := operation(args)!`.
+- Use `?` only in a function that returns an error. When the resolved lifecycle
+  callback returns no error, use `!` or inspect the error there. Use `?:` only
+  for a source-backed default, not as a defensive fallback for a failed build
+  operation.
 - Inspect an error explicitly when absence, unsupported input, or another error
   class changes the Formula's behavior.
 - Accumulate errors only when the active Formula contract exposes an error list
@@ -101,12 +119,17 @@ does not turn command strings into a POSIX shell language.
   Do not wrap such a command in `exec` merely because it has flags or multiple
   arguments.
 - Use `exec` only for paths, names containing punctuation, keywords, collisions,
-  or explicit environment overlays.
+  or explicit environment overlays. Prefer the map overload for a per-command
+  overlay, for example
+  `exec! {"CC": compiler}, "./configure", "--disable-shared"`.
 - Use `capout` only when the Formula consumes stdout. Put `!` on a required
-  command inside the capture block before reading `output`.
+  command inside the capture block before reading `output`; stderr is not part
+  of the captured value.
 - Use the explicit argument form when arguments must remain separate.
-- Treat the one-string `exec` form as field splitting plus environment
-  expansion unless the selected gsh source proves otherwise.
+- Treat the one-string `exec` form as whitespace splitting followed by
+  environment expansion, without resplitting, unless the selected gsh source
+  proves otherwise. Quotes do not group fields under this implementation, and
+  prefix overlays do not affect later `$NAME` expansion in the same string.
 - Invoke a verified shell explicitly when a build step truly requires pipes,
   redirection, globbing, command substitution, or shell operators.
 
@@ -124,5 +147,5 @@ Using a Go package does not make Formula source Go-first. XGo is designed to
 call Go libraries. Use structured Go APIs through XGo spelling for JSON, YAML,
 filesystem traversal, archive formats, and source manifest parsing instead of
 reimplementing parsers with shell text processing. XGo exposes common `fmt`
-operations as builtins; use `fprintf!`, `sprintf`, `errorf`, and related forms
-without importing or qualifying `fmt`.
+operations as builtins; use `fprintf!`, `fprintln!`, `sprintf`, `errorf`, and
+related forms without importing or qualifying `fmt`.

--- a/.claude/skills/write-formula/references/xgo-gsh-style.md
+++ b/.claude/skills/write-formula/references/xgo-gsh-style.md
@@ -12,12 +12,16 @@ Reuse applicable idioms demonstrated there:
 - auto-properties such as `entry.isDir`, `output.trimSpace`, and `values.len`;
 - XGo loops such as `for value in values`;
 - lambdas such as `(_, entry, err) => { ... }`;
-- list comprehensions for real collection transformations;
+- direct list comprehensions for complete collection transformations;
 - typed empty collections when the empty value's type or encoded form matters;
-- `<-` for slice append;
+- `<-` only for genuine incremental slice append;
 - `expr!` for operations that must succeed;
 - `$NAME` for environment values exposed by the gsh class;
-- direct commands, `capout`, `lastErr!`, and `output` for external processes.
+- `command! args`, `capout => { command! args }`, and `output` for required
+  external processes;
+- `${expr}` for plain string construction and panic messages;
+- unqualified format builtins such as `fprintf!` when a format string is
+  clearer than interpolation.
 
 Do not copy its Git diff policy, GitHub output handling, filesystem rules, or
 top-level execution shape into a Formula. A `.gsh` project executes its script
@@ -30,7 +34,8 @@ rules below.
 
 ## XGo-First Formula Style
 
-Prefer verified XGo forms whenever they express the same behavior directly:
+Prefer the shortest verified XGo form whenever it expresses the same behavior
+directly:
 
 - Write callback values as lambdas.
 - Omit parentheses for a side-effect-only statement call.
@@ -41,7 +46,23 @@ Prefer verified XGo forms whenever they express the same behavior directly:
   equivalent operation supported by the active XGo version.
 - Use a comprehension when it is a direct filter or transform, not when it
   hides stateful control flow or changes empty-value semantics.
-- Use `operation()!` when every failure must abort the current panic boundary.
+- Use command-style calls and `!` when every failure must abort the current
+  panic boundary.
+- Use unqualified XGo builtins instead of a `fmt.` prefix. Prefer `${expr}` to
+  `sprintf` when no formatting directive is needed.
+- When an interpolation expression needs a string literal, use a raw string
+  inside the braces, for example `${values.join(`, `)}`.
+
+For example:
+
+```xgo
+capout => { git! "merge-base", baseSHA, headSHA }
+diffBase := output.trimSpace
+
+changedModules := [module for module, _ in modules]
+panic "invalid module ${module}"
+fprintf! outputFile, "modules=%s\n", modulesJSON
+```
 
 After drafting, review Go-shaped candidates such as unused-index `range` loops,
 manual panic-on-error blocks, uppercase imported calls, and parenthesized
@@ -57,11 +78,15 @@ type conversions solely to demonstrate language features.
 Match syntax to semantics:
 
 - Use `!` for a required operation whose only valid result is success.
+- For a required gsh command, attach `!` to the command itself. Inside a
+  capture block, write `capout => { command! args }`.
 - Inspect an error explicitly when absence, unsupported input, or another error
   class changes the Formula's behavior.
 - Accumulate errors only when the active Formula contract exposes an error list
   and the operations are genuinely independent.
-- Check gsh command status immediately; the next command replaces `lastErr`.
+- Read `lastErr` only when command failure is an expected value that selects a
+  verified branch. Do not use `lastErr!` after a required command when the
+  command-style `!` form is available.
 
 Do not replace meaningful error classification with `!`. Do not expand a
 required operation into repetitive `if err != nil { panic err }` code.
@@ -77,8 +102,8 @@ does not turn command strings into a POSIX shell language.
   arguments.
 - Use `exec` only for paths, names containing punctuation, keywords, collisions,
   or explicit environment overlays.
-- Use `capout` only when the Formula consumes stdout; validate the command before
-  reading `output`.
+- Use `capout` only when the Formula consumes stdout. Put `!` on a required
+  command inside the capture block before reading `output`.
 - Use the explicit argument form when arguments must remain separate.
 - Treat the one-string `exec` form as field splitting plus environment
   expansion unless the selected gsh source proves otherwise.
@@ -98,4 +123,6 @@ command and compile through the active ixgo path.
 Using a Go package does not make Formula source Go-first. XGo is designed to
 call Go libraries. Use structured Go APIs through XGo spelling for JSON, YAML,
 filesystem traversal, archive formats, and source manifest parsing instead of
-reimplementing parsers with shell text processing.
+reimplementing parsers with shell text processing. XGo exposes common `fmt`
+operations as builtins; use `fprintf!`, `sprintf`, `errorf`, and related forms
+without importing or qualifying `fmt`.

--- a/.claude/skills/write-formula/references/xgo-gsh-style.md
+++ b/.claude/skills/write-formula/references/xgo-gsh-style.md
@@ -38,7 +38,8 @@ rules below.
 Use the simplest verified XGo form whenever it expresses the same behavior
 directly:
 
-- Write callback values as lambdas.
+- Write callback values as lambdas when the target API supplies an expected
+  function type; an untyped standalone lambda has no context for inference.
 - Omit parentheses for a side-effect-only statement call.
 - Use lowercase aliases for exported Go functions and methods.
 - Use auto-properties for zero-argument getters.
@@ -77,6 +78,29 @@ directly:
   ixgo cannot interpolate, such as `bool` or `[]byte`.
 - Do not call compiler implementation helpers such as `stringutil.Concat` from
   a Formula; resolve the supported syntax against LLAR's active ixgo toolchain.
+
+### Collections And Control Flow
+
+- Use inferred list literals `[value1, value2]` and map literals
+  `{"key": value}` for non-empty collections. Give an empty collection an
+  explicit slice or map type, or use `make`, when later assignment or encoding
+  depends on its concrete element types.
+- Use list and map comprehensions for direct transforms and filters, for
+  example `[f(value) for value in values if keep(value)]` and
+  `{key(value): value for value in values}`. Keep side effects and multi-step
+  logic in a loop.
+- Use `for value in values`, `for key, value in mapping`, and a trailing `if`
+  on a `for` loop when the body performs filtered side effects. Use
+  `for i in start:end:step` for a numeric sequence; retain a C-style loop only
+  when its mutable state is the clearest form.
+- Use `<-` only for genuine incremental slice append. Use `append` when the
+  returned slice is the value being composed or passed onward.
+- Compare a map, slice, or pointer with `nil` only when the producing API can
+  return nil. A nil map cannot accept entry assignments; initialize it before
+  writing entries, and do not add nil checks as generic defensive code.
+- Use comma-ok map access when missing data has a verified meaning, for example
+  `value, ok := mapping[key]`; do not use it to hide a required configuration
+  error.
 
 For example:
 
@@ -138,7 +162,9 @@ does not turn command strings into a POSIX shell language.
   `exec! {"CC": compiler}, "./configure", "--disable-shared"`.
 - Use `capout` only when the Formula consumes stdout. Put `!` on a required
   command inside the capture block before reading `output`; stderr is not part
-  of the captured value.
+  of the captured value. Under LLAR's broker, this captures gsh child-command
+  stdout; it does not make arbitrary XGo `echo` or `println` output part of
+  `output`.
 - Use the explicit argument form when arguments must remain separate.
 - Treat the one-string `exec` form as whitespace splitting followed by
   environment expansion, without resplitting, unless the selected gsh source
@@ -163,3 +189,18 @@ filesystem traversal, archive formats, and source manifest parsing instead of
 reimplementing parsers with shell text processing. XGo exposes common `fmt`
 operations as builtins; use `fprintf!`, `fprintln!`, `sprintf`, `errorf`, and
 related forms without importing or qualifying `fmt`.
+
+Imports remain explicit unless the resolved LLAR `gox.mod` registers an
+auto-import. In the pinned Formula contract, `cmake` and `autotools` are
+registered helpers; ordinary packages such as `os`, `strings`, `slices`, and
+`encoding/json` still require an import. Resolve this list against the active
+LLAR revision instead of assuming a helper is globally available.
+
+Use lowercase XGo aliases and auto-properties only for verified exported Go
+functions and zero-argument getters, such as `filepath.join`, `ctx.outputDir`,
+and `entry.isDir`. Keep parentheses for nested calls and calls whose result is
+consumed; omit them for side-effect-only command statements. LLAR build
+helpers whose methods return no error, such as
+`c.configure`, `c.build`, `c.install`, and `pkgconfig.use`, are called directly;
+use `!` for separate gsh or Go operations that return an error, such as
+`pkgconfig.lookup`.


### PR DESCRIPTION
This PR makes the `write-formula` skill require the simplest verified XGo and gsh form without hard-coding a moving LLAR API snapshot.

The implementation includes:

- prefer command-style `command! args`, direct comprehensions, collection queries, auto-properties, and unqualified format builtins
- scope `!`, `?`, and `?:` to their verified error contracts, including void CMake and Autotools helpers that already fail internally
- document interpolation, map-length, `exec`, environment-overlay, and `capout` boundaries proven against the active ixgo, XGo, and gsh implementations
- separate the llarhub CI script toolchain from the ixgo version pinned by LLAR and require source, callback, helper, and selection-contract discovery
- retain Formula invariants for lowest-compatible `fromVer`, full-set comparator validation, lowercase llarhub filenames, complete pkg-config metadata, and cache-safe consumer tests

This favors semantic simplicity over character count while keeping Formula behavior tied to executable evidence from the selected LLAR revision.