### PR TITLE
feat(yyjson): add LLAR formula

### DIFF
--- a/ibireme/yyjson/0.9.0/yyjson_llar.gox
+++ b/ibireme/yyjson/0.9.0/yyjson_llar.gox
@@ -1,0 +1,117 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <yyjson.h>
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+    const char *json = "{\"name\":\"Mash\",\"star\":4,\"hits\":[2,2,1,3]}";
+
+    yyjson_doc *doc = yyjson_read(json, strlen(json), 0);
+    yyjson_val *root = yyjson_doc_get_root(doc);
+
+    yyjson_val *name = yyjson_obj_get(root, "name");
+    printf("name: %s\n", yyjson_get_str(name));
+    printf("name length:%d\n", (int)yyjson_get_len(name));
+
+    yyjson_val *star = yyjson_obj_get(root, "star");
+    printf("star: %d\n", (int)yyjson_get_int(star));
+
+    yyjson_val *hits = yyjson_obj_get(root, "hits");
+    size_t idx, max;
+    yyjson_val *hit;
+    yyjson_arr_foreach(hits, idx, max, hit) {
+        printf("hit%d: %d\n", (int)idx, (int)yyjson_get_int(hit));
+    }
+
+    yyjson_doc_free(doc);
+
+    return 0;
+}
+`
+
+id "ibireme/yyjson"
+
+fromVer "0.9.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"with_utf8_validation": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" && name != "with_utf8_validation" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	withUtf8Validation := slices.contains(target.options["with_utf8_validation"], "ON")
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "YYJSON_DISABLE_UTF8_VALIDATION", !withUtf8Validation
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	// CMake writes prefix, libdir, and includedir from CMAKE_INSTALL_PREFIX.
+	// Keep the generated flags and make the installed file relocatable.
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", "yyjson.pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix="+installDir, "prefix=$${pcfiledir}/../..", 1)
+	pc = strings.replace(pc, "exec_prefix="+installDir, "exec_prefix=$${prefix}", 1)
+	pc = strings.replace(pc, "libdir="+filepath.join(installDir, "lib"), "libdir=$${prefix}/lib", 1)
+	pc = strings.replace(pc, "includedir="+filepath.join(installDir, "include"), "includedir=$${prefix}/include", 1)
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("yyjson")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.c")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "yyjson.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("yyjson")!), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	cc! consumer, "-o", binary, "@"+flagsFile
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/ibireme/yyjson/versions.json
+++ b/ibireme/yyjson/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "ibireme/yyjson",
+  "deps": {}
+}


### PR DESCRIPTION
Closes #58

Translate the Conan Center `yyjson` recipe into an LLAR Formula for `ibireme/yyjson`.

- `fromVer` is `0.9.0`, the lowest tag in this Conan recipe with the same CMake install and `yyjson.pc` contract as 0.10.0 and 0.12.0.
- Options: `shared`, `fPIC`, `with_utf8_validation` (Conan default True maps to `YYJSON_DISABLE_UTF8_VALIDATION=OFF`).
- Keep the upstream pkg-config file and rewrite its baked `CMAKE_INSTALL_PREFIX` to relocatable `${pcfiledir}/../..`.
- Metadata is the complete `pkg-config --cflags --libs` lookup.
- `onTest` compiles the Conan `test_package.c` consumer (plus `string.h`) with those lookup flags.