### PR TITLE
feat(cpu_features): add LLAR formula

### DIFF
--- a/google/cpu_features/v0.9.0/cpu_features_llar.gox
+++ b/google/cpu_features/v0.9.0/cpu_features_llar.gox
@@ -1,0 +1,146 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+const consumerSource = `#include <cpu_features_macros.h>
+#if defined(CPU_FEATURES_ARCH_X86)
+#include <cpuinfo_x86.h>
+#elif defined(CPU_FEATURES_ARCH_ARM)
+#include <cpuinfo_arm.h>
+#elif defined(CPU_FEATURES_ARCH_AARCH64)
+#include <cpuinfo_aarch64.h>
+#elif defined(CPU_FEATURES_ARCH_MIPS)
+#include <cpuinfo_mips.h>
+#elif defined(CPU_FEATURES_ARCH_PPC)
+#include <ccpuinfo_ppc.h>
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+
+int main()
+{
+#if defined(CPU_FEATURES_ARCH_X86)
+    X86Features features = GetX86Info().features;
+#elif defined(CPU_FEATURES_ARCH_ARM)
+    ArmFeatures features = GetArmInfo().features;
+#elif defined(CPU_FEATURES_ARCH_AARCH64)
+    Aarch64Features features = GetAarch64Info().features;
+#elif defined(CPU_FEATURES_ARCH_MIPS)
+    MipsFeatures features = GetMipsInfo().features;
+#elif defined(CPU_FEATURES_ARCH_PPC)
+    PPCFeatures features = GetPPCInfo().features;
+#endif
+
+#if defined(CPU_FEATURES_ARCH_X86) || defined(CPU_FEATURES_ARCH_ARM) || defined(CPU_FEATURES_ARCH_AARCH64)
+    printf("AES is%s available\n", features.aes ? "" : "n't");
+#elif defined(CPU_FEATURES_ARCH_MIPS)
+    printf("EVA is%s available\n", features.eva ? "" : "n't");
+#elif defined(CPU_FEATURES_ARCH_PPC)
+    printf("SPE is%s available\n", features.spe ? "" : "n't");
+#endif
+
+    return EXIT_SUCCESS;
+}
+`
+
+id "google/cpu_features"
+
+fromVer "v0.9.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "BUILD_TESTING", false
+	c.defineBool "CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS", true
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	version := ""
+	for line in string(os.readFile(filepath.join(ctx.SourceDir, "CMakeLists.txt"))!).split("\n") {
+		if line.hasPrefix("project(CpuFeatures VERSION ") {
+			version = line.trimPrefix("project(CpuFeatures VERSION ").split(" ")[0]
+			break
+		}
+	}
+	if version == "" {
+		panic "cpu_features CMakeLists.txt has no project version"
+	}
+
+	libs := "-L$${libdir} -lcpu_features"
+	if slices.contains(target.require["os"], "linux") || slices.contains(target.require["os"], "freebsd") {
+		libs += " -ldl"
+	}
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: cpu_features
+Description: A cross platform C99 library to get cpu features at runtime
+Version: ` + version + `
+Libs: ` + libs + `
+Cflags: -I$${includedir}/cpu_features
+`
+	os.writeFile(filepath.join(pcDir, "cpu_features.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("cpu_features")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.c")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flags := pkgconfig.lookup("cpu_features")!
+	flagsFile := filepath.join(testDir, "cpu_features.flags")
+	os.writeFile(flagsFile, []byte(flags), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	cc! "-std=c99", consumer, "-o", binary, "@"+flagsFile
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/google/cpu_features/versions.json
+++ b/google/cpu_features/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "google/cpu_features",
+	"deps": {}
+}


### PR DESCRIPTION
Closes #36

Translate the Conan Center `cpu_features` recipe (`ffe30df101afd4dc95aac2f14b25bf345e64d7be`) into an LLAR Formula for `google/cpu_features`.

## Formula
- Module: `google/cpu_features`
- `fromVer`: `v0.9.0` (Conan recipe covers `0.9.0` / `0.10.1`; CMake install layout, public headers under `include/cpu_features`, and consumer contract match)
- Options: `shared` (default `OFF`), `fPIC` (default `ON`)
- CMake: `BUILD_TESTING=OFF`, `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON`, `CMAKE_INSTALL_LIBDIR=lib`, `BUILD_SHARED_LIBS` / `CMAKE_POSITION_INDEPENDENT_CODE` from options
- LICENSE copied to `licenses/`

## pkg-config
Upstream does not install a `.pc` file. The Formula writes relocatable `lib/pkgconfig/cpu_features.pc`:
- `prefix=${pcfiledir}/../..`
- `Cflags: -I${includedir}/cpu_features` so the Conan test can `#include <cpu_features_macros.h>`
- `Libs: -L${libdir} -lcpu_features` plus `-ldl` on Linux/FreeBSD (Conan `system_libs = ["dl"]`; placed in `Libs` so default static `pkgconfig.lookup` is enough)
- metadata is the complete `pkg-config --cflags --libs` lookup
- `onTest` compiles the Conan `test_package.c` consumer with a flags file from that lookup

Apple `CMAKE_SYSTEM_PROCESSOR=aarch64` is not set: v0.9.0+ already matches Darwin's `arm64`, and CI is linux/darwin only. Android `ndk_compat` is not exposed.