### PR TITLE
docs: require cmake/autotools helpers in onBuild

### DIFF
--- a/.agents/skills/write-formula/SKILL.md
+++ b/.agents/skills/write-formula/SKILL.md
@@ -54,9 +54,12 @@ documentation as a substitute for that source.
 
 Choose the narrowest owner for each operation:
 
-- Use LLAR's CMake or Autotools helper for behavior it already owns.
+- Use LLAR's CMake or Autotools helper for compile, archive, link, and
+  install. Those helpers run `cmake`/`configure`/`make` through LLAR's
+  execbroker so a later cross-compile toolchain and sysroot can be injected.
 - Use the inherited gsh surface for external commands, command environment,
-  captured output, and command status.
+  captured output, and command status. Do not use gsh `cc`, `c++`, `ar`, or
+  `ld` from `onBuild` as a substitute for a helper.
 - Use XGo collection, string, lambda, property, command-call, and error-wrap
   forms for Formula logic when the active ixgo accepts them.
 - Use Go standard-library packages through their XGo surface for structured
@@ -101,6 +104,21 @@ LLAR's configured streams, working directory, and execution path.
   fragment, or a libs-only query, for the complete result.
 - Keep consumer tests independent of the build scratch tree so they can run on
   a cache hit.
+- In `onBuild`, compile and install C/C++ packages only through the LLAR
+  CMake or Autotools helper. Do not call `cc`, `c++`, `gcc`, `clang`, `ar`,
+  `ld`, or equivalent compilers and archivers from `onBuild`. Naked compiler
+  invocations skip execbroker and block later LLAR cross-compile injection.
+- Match the helper to upstream: CMake when the selected revision has
+  `CMakeLists.txt`; Autotools when it has `configure` and/or a Makefile. Do
+  not invent a `CMakeLists.txt` or a replacement Makefile. Drive the
+  existing Makefile with `a.build` and `a.install`, passing make variables
+  such as `CFLAGS=` and explicit targets when the default target is tests.
+  Skip `a.configure` when there is no configure script. If the Makefile has
+  no `install` target, still compile through `a.build`, then copy the files
+  make produced into the output directory.
+- `onTest` may compile the consumer with `cc!` or `c++!` against installed
+  pkg-config flags. That is the only Formula hook where a naked compiler is
+  allowed.
 - Do not add compatibility paths, fallback behavior, flags, generators,
   options, abstractions, or helpers without evidence that the current Formula
   needs them.

--- a/.agents/skills/write-formula/references/formula-semantics.md
+++ b/.agents/skills/write-formula/references/formula-semantics.md
@@ -87,15 +87,41 @@ only source-backed flags. Do not force a generator, build type, linkage mode,
 toolchain, policy version, test toggle, or optional feature because another
 Formula used it.
 
+Choose the helper from the selected upstream revision:
+
+- CMake when the source has `CMakeLists.txt`.
+- Autotools when the source has `configure` and/or a Makefile, including
+  Makefile-only trees. Autotools `build`/`install` run `make`/`make install`
+  through execbroker.
+
+Do not invent a `CMakeLists.txt` for a Makefile project. Do not call `cc`,
+`c++`, `gcc`, `clang`, `ar`, `ld`, or equivalent compilers and archivers from
+`onBuild`. Those helpers are the injection point for later LLAR cross-compile
+toolchains and sysroots; a host compiler invoked from the Formula skips that
+path.
+
+Keep the Autotools helper for Makefile projects even when the default target
+is a test program or there is no `install` rule. Do not invent a replacement
+Makefile. Call `a.build` with the existing Makefile's compile targets and
+make variables such as `CFLAGS=`; skip `a.configure` when there is no
+configure script. If there is no `install` target, copy the files make
+produced into the output directory instead of calling `a.install`.
+
+`onTest` may compile a consumer with `cc!` or `c++!` against the installed
+pkg-config flags. That is the only Formula hook where a naked compiler is
+allowed.
+
 Expose dependency install roots through the active helper or context contract.
 Install the complete public result into the current module's output directory.
 Do not depend on a build scratch path after the build callback returns.
 
-For an unsupported build system, use gsh commands with separate arguments and
-explicit failure propagation. Call active CMake or Autotools helper methods
-according to their real return contract; do not add `!` to a void helper that
-already panics on failure. Add a shell only when the verified upstream step
-requires shell grammar.
+For an unsupported build system that is not CMake or Make, use gsh commands
+with separate arguments and explicit failure propagation. Still do not invoke
+a C/C++ compiler from `onBuild` when a Makefile plus the Autotools helper can
+own the compile. Call active CMake or Autotools helper methods according to
+their real return contract; do not add `!` to a void helper that already
+panics on failure. Add a shell only when the verified upstream step requires
+shell grammar.
 
 ## Metadata
 

--- a/.agents/skills/write-formula/references/xgo-gsh-style.md
+++ b/.agents/skills/write-formula/references/xgo-gsh-style.md
@@ -173,9 +173,13 @@ does not turn command strings into a POSIX shell language.
 - Invoke a verified shell explicitly when a build step truly requires pipes,
   redirection, globbing, command substitution, or shell operators.
 
-Keep build commands inside `onBuild` or `onTest`. Prefer the active LLAR CMake or
-Autotools helper when it owns the upstream build flow; use gsh for unsupported
-build systems and additional source-backed steps.
+Keep build commands inside `onBuild` or `onTest`. In `onBuild`, compile C/C++
+packages with the active LLAR CMake or Autotools helper so `cmake`,
+`configure`, and `make` run through execbroker. Do not call gsh `cc`, `c++`,
+`ar`, or `ld` from `onBuild`; that skips later LLAR cross-compile toolchain
+injection. `onTest` may use `cc!` or `c++!` to compile the consumer against
+installed metadata. Use gsh for non-compile steps and for build systems that
+are not CMake or Make.
 
 During the final style pass, review every `exec "literal-name", ...` call. When
 the literal is a valid, unshadowed identifier, rewrite it as a direct gsh

--- a/.claude/skills/write-formula/SKILL.md
+++ b/.claude/skills/write-formula/SKILL.md
@@ -56,9 +56,12 @@ documentation as a substitute for that source.
 
 Choose the narrowest owner for each operation:
 
-- Use LLAR's CMake or Autotools helper for behavior it already owns.
+- Use LLAR's CMake or Autotools helper for compile, archive, link, and
+  install. Those helpers run `cmake`/`configure`/`make` through LLAR's
+  execbroker so a later cross-compile toolchain and sysroot can be injected.
 - Use the inherited gsh surface for external commands, command environment,
-  captured output, and command status.
+  captured output, and command status. Do not use gsh `cc`, `c++`, `ar`, or
+  `ld` from `onBuild` as a substitute for a helper.
 - Use XGo collection, string, lambda, property, command-call, and error-wrap
   forms for Formula logic when the active ixgo accepts them.
 - Use Go standard-library packages through their XGo surface for structured
@@ -103,6 +106,21 @@ LLAR's configured streams, working directory, and execution path.
   fragment, or a libs-only query, for the complete result.
 - Keep consumer tests independent of the build scratch tree so they can run on
   a cache hit.
+- In `onBuild`, compile and install C/C++ packages only through the LLAR
+  CMake or Autotools helper. Do not call `cc`, `c++`, `gcc`, `clang`, `ar`,
+  `ld`, or equivalent compilers and archivers from `onBuild`. Naked compiler
+  invocations skip execbroker and block later LLAR cross-compile injection.
+- Match the helper to upstream: CMake when the selected revision has
+  `CMakeLists.txt`; Autotools when it has `configure` and/or a Makefile. Do
+  not invent a `CMakeLists.txt` or a replacement Makefile. Drive the
+  existing Makefile with `a.build` and `a.install`, passing make variables
+  such as `CFLAGS=` and explicit targets when the default target is tests.
+  Skip `a.configure` when there is no configure script. If the Makefile has
+  no `install` target, still compile through `a.build`, then copy the files
+  make produced into the output directory.
+- `onTest` may compile the consumer with `cc!` or `c++!` against installed
+  pkg-config flags. That is the only Formula hook where a naked compiler is
+  allowed.
 - Do not add compatibility paths, fallback behavior, flags, generators,
   options, abstractions, or helpers without evidence that the current Formula
   needs them.

--- a/.claude/skills/write-formula/references/formula-semantics.md
+++ b/.claude/skills/write-formula/references/formula-semantics.md
@@ -87,15 +87,41 @@ only source-backed flags. Do not force a generator, build type, linkage mode,
 toolchain, policy version, test toggle, or optional feature because another
 Formula used it.
 
+Choose the helper from the selected upstream revision:
+
+- CMake when the source has `CMakeLists.txt`.
+- Autotools when the source has `configure` and/or a Makefile, including
+  Makefile-only trees. Autotools `build`/`install` run `make`/`make install`
+  through execbroker.
+
+Do not invent a `CMakeLists.txt` for a Makefile project. Do not call `cc`,
+`c++`, `gcc`, `clang`, `ar`, `ld`, or equivalent compilers and archivers from
+`onBuild`. Those helpers are the injection point for later LLAR cross-compile
+toolchains and sysroots; a host compiler invoked from the Formula skips that
+path.
+
+Keep the Autotools helper for Makefile projects even when the default target
+is a test program or there is no `install` rule. Do not invent a replacement
+Makefile. Call `a.build` with the existing Makefile's compile targets and
+make variables such as `CFLAGS=`; skip `a.configure` when there is no
+configure script. If there is no `install` target, copy the files make
+produced into the output directory instead of calling `a.install`.
+
+`onTest` may compile a consumer with `cc!` or `c++!` against the installed
+pkg-config flags. That is the only Formula hook where a naked compiler is
+allowed.
+
 Expose dependency install roots through the active helper or context contract.
 Install the complete public result into the current module's output directory.
 Do not depend on a build scratch path after the build callback returns.
 
-For an unsupported build system, use gsh commands with separate arguments and
-explicit failure propagation. Call active CMake or Autotools helper methods
-according to their real return contract; do not add `!` to a void helper that
-already panics on failure. Add a shell only when the verified upstream step
-requires shell grammar.
+For an unsupported build system that is not CMake or Make, use gsh commands
+with separate arguments and explicit failure propagation. Still do not invoke
+a C/C++ compiler from `onBuild` when a Makefile plus the Autotools helper can
+own the compile. Call active CMake or Autotools helper methods according to
+their real return contract; do not add `!` to a void helper that already
+panics on failure. Add a shell only when the verified upstream step requires
+shell grammar.
 
 ## Metadata
 

--- a/.claude/skills/write-formula/references/xgo-gsh-style.md
+++ b/.claude/skills/write-formula/references/xgo-gsh-style.md
@@ -173,9 +173,13 @@ does not turn command strings into a POSIX shell language.
 - Invoke a verified shell explicitly when a build step truly requires pipes,
   redirection, globbing, command substitution, or shell operators.
 
-Keep build commands inside `onBuild` or `onTest`. Prefer the active LLAR CMake or
-Autotools helper when it owns the upstream build flow; use gsh for unsupported
-build systems and additional source-backed steps.
+Keep build commands inside `onBuild` or `onTest`. In `onBuild`, compile C/C++
+packages with the active LLAR CMake or Autotools helper so `cmake`,
+`configure`, and `make` run through execbroker. Do not call gsh `cc`, `c++`,
+`ar`, or `ld` from `onBuild`; that skips later LLAR cross-compile toolchain
+injection. `onTest` may use `cc!` or `c++!` to compile the consumer against
+installed metadata. Use gsh for non-compile steps and for build systems that
+are not CMake or Make.
 
 During the final style pass, review every `exec "literal-name", ...` call. When
 the literal is a valid, unshadowed identifier, rewrite it as a direct gsh


### PR DESCRIPTION
Naked `cc`/`ar` in `onBuild` skips execbroker and blocks later LLAR cross-compile toolchain injection.

- Compile C/C++ packages through the CMake or Autotools helper.
- Drive an existing Makefile with `a.build` / `a.install`; do not invent CMakeLists or a replacement Makefile.
- `onTest` may still compile consumers with `cc`.