### PR TITLE
feat(id3v2lib): add LLAR formula

### DIFF
--- a/larsbs/id3v2lib/2.1/id3v2lib_llar.gox
+++ b/larsbs/id3v2lib/2.1/id3v2lib_llar.gox
@@ -1,0 +1,102 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+const consumerSource = `#include <id3v2lib-2.0/id3v2lib.h>
+#include <stdio.h>
+
+int main(void) {
+  ID3v2_Tag *tag = ID3v2_Tag_new_empty();
+  ID3v2_Tag_set_title(tag, "Amazing Song!");
+
+  ID3v2_TextFrame *title_frame = ID3v2_Tag_get_title_frame(tag);
+  printf("Track title: %s\n", title_frame->data->text);
+
+  ID3v2_Tag_free(tag);
+  return 0;
+}
+`
+
+id "larsbs/id3v2lib"
+
+fromVer "2.1"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	// Upstream CMake installs headers and the library but no pkg-config file.
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: id3v2lib
+Description: Library to read and edit id3 tags from mp3 files
+Version: 2.1
+Libs: -L$${libdir} -lid3v2lib
+Cflags: -I$${includedir}
+`
+	os.writeFile(filepath.join(pcDir, "id3v2lib.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("id3v2lib")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.c")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "id3v2lib.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("id3v2lib")!), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	cc! consumer, "-o", binary, "@"+flagsFile
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/larsbs/id3v2lib/versions.json
+++ b/larsbs/id3v2lib/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "larsbs/id3v2lib",
+  "deps": {}
+}


### PR DESCRIPTION
Closes #28

- Add `larsbs/id3v2lib` Formula for upstream tag `2.1` from the Conan Center snapshot.
- Preserve Conan `shared`/`fPIC` defaults, CMake install layout (`CMAKE_INSTALL_LIBDIR=lib`), and the `LICENSE` file.
- Upstream CMake does not install pkg-config metadata, so publish a relocatable `id3v2lib.pc` and compile the Conan `test_package.c` consumer (`<id3v2lib-2.0/id3v2lib.h>`) with pkg-config flags.

Validation: `llar test -v ./larsbs/id3v2lib@2.1` passed, including a cache-hit retest.