### PR TITLE
feat(kissfft): add LLAR formula

### DIFF
--- a/mborgerding/kissfft/131.1.0/kissfft_llar.gox
+++ b/mborgerding/kissfft/131.1.0/kissfft_llar.gox
@@ -1,0 +1,122 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <kiss_fft.h>
+
+#include <stdio.h>
+
+int main()
+{
+    printf("kiss_fft_next_fast_size(1) = %i\n", kiss_fft_next_fast_size(1));
+    return 0;
+}
+`
+
+id "mborgerding/kissfft"
+
+fromVer "131.1.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"datatype": "float",
+	"openmp": "OFF",
+	"use_alloca": "OFF",
+}
+
+filter => {
+	datatypes := ["float", "double", "int16_t", "int32_t", "simd"]
+	for name, values in target.options {
+		switch name {
+		case "shared", "fPIC", "openmp", "use_alloca":
+			for value in values {
+				if value != "ON" && value != "OFF" {
+					return false
+				}
+			}
+		case "datatype":
+			for value in values {
+				if !slices.contains(datatypes, value) {
+					return false
+				}
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+	openmp := slices.contains(target.options["openmp"], "ON")
+	useAlloca := slices.contains(target.options["use_alloca"], "ON")
+	datatype := target.options["datatype"][0]
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.define "CMAKE_INSTALL_INCLUDEDIR", "include"
+	c.define "KISSFFT_DATATYPE", datatype
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "KISSFFT_PKGCONFIG", true
+	c.defineBool "KISSFFT_STATIC", !shared
+	c.defineBool "KISSFFT_TEST", false
+	c.defineBool "KISSFFT_TOOLS", false
+	c.defineBool "KISSFFT_OPENMP", openmp
+	c.defineBool "KISSFFT_USE_ALLOCA", useAlloca
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "COPYING"), os.readFile(filepath.join(ctx.SourceDir, "COPYING"))!, 0o644)!
+
+	pcName := "kissfft-" + datatype
+	if openmp {
+		pcName += "-openmp"
+	}
+
+	// CMake writes prefix from CMAKE_INSTALL_PREFIX. Keep the generated
+	// flags and make the installed file relocatable.
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", pcName+".pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix="+installDir, "prefix=$${pcfiledir}/../..", 1)
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup(pcName)!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.c")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pcName := "kissfft-" + target.options["datatype"][0]
+	if slices.contains(target.options["openmp"], "ON") {
+		pcName += "-openmp"
+	}
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "kissfft.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup(pcName)!), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	cc! consumer, "-o", binary, "@"+flagsFile
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/mborgerding/kissfft/versions.json
+++ b/mborgerding/kissfft/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "mborgerding/kissfft",
+	"deps": {}
+}


### PR DESCRIPTION
Convert the Conan Center kissfft recipe into an LLAR Formula.

- Module: `mborgerding/kissfft`
- fromVer: `131.1.0` (CMakeLists exists from this tag; `v130`/`v131` are Makefile-only)
- Helper: cmake
- Keep the generated pkg-config file and rewrite `prefix` to `${pcfiledir}/../..`
- Consumer: Conan `test_package.c`

Closes https://github.com/xgo-dev/llarhub/issues/72