### PR TITLE
feat(CRoaring): add LLAR formula

### DIFF
--- a/RoaringBitmap/CRoaring/v4.7.0/roaring_llar.gox
+++ b/RoaringBitmap/CRoaring/v4.7.0/roaring_llar.gox
@@ -1,0 +1,127 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <iostream>
+
+#include "roaring/roaring.h"
+#include "roaring/roaring.hh"
+
+using namespace roaring;
+
+int main() {
+    Roaring r1;
+    for (uint32_t i = 100; i < 1000; i++) {
+        r1.add(i);
+    }
+
+    assert(r1.contains(500));
+
+    uint64_t cardinality = r1.cardinality();
+    std::cout << "Cardinality = " << cardinality << std::endl;
+
+    size_t size = r1.getSizeInBytes();
+    r1.runOptimize();
+    size_t compact_size = r1.getSizeInBytes();
+    std::cout << "size before run optimize " << size << " bytes, and after "
+              << compact_size << " bytes." << std::endl;
+
+    Roaring r2 = Roaring::bitmapOf(5, 1, 2, 3, 5, 6);
+    r2.printf();
+    printf("\n");
+
+    uint32_t element;
+    r2.select(3, &element);
+    assert(element == 5);
+    assert(r2.minimum() == 1);
+    assert(r2.maximum() == 6);
+    assert(r2.rank(4) == 3);
+    return EXIT_SUCCESS;
+}
+`
+
+id "RoaringBitmap/CRoaring"
+
+fromVer "v4.7.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := slices.contains(target.options["shared"], "ON")
+	fPIC := slices.contains(target.options["fPIC"], "ON")
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "ROARING_BUILD_STATIC", !shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "ENABLE_ROARING_TESTS", false
+	c.defineBool "ENABLE_ROARING_MICROBENCHMARKS", false
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	// CMake writes prefix from CMAKE_INSTALL_PREFIX. Keep the generated flags
+	// and make the installed file relocatable.
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", "roaring.pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix="+installDir, "prefix=$${pcfiledir}/../..", 1)
+	pc = strings.replace(pc, "exec_prefix="+installDir, "exec_prefix=$${prefix}", 1)
+	pc = strings.replace(pc, "libdir="+filepath.join(installDir, "lib"), "libdir=$${prefix}/lib", 1)
+	pc = strings.replace(pc, "includedir="+filepath.join(installDir, "include"), "includedir=$${prefix}/include", 1)
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("roaring")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "roaring.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("roaring")!), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	exec! "c++", "-std=c++11", consumer, "-o", binary, "@"+flagsFile
+
+	if slices.contains(target.options["shared"], "ON") {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/RoaringBitmap/CRoaring/versions.json
+++ b/RoaringBitmap/CRoaring/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "RoaringBitmap/CRoaring",
+	"deps": {}
+}


### PR DESCRIPTION
Closes #73

Translate the Conan Center `roaring` recipe into an LLAR Formula for `RoaringBitmap/CRoaring`.

- `fromVer` is `v4.7.0`, the lowest CMake 3.15 tag with the same roaring install and `roaring.pc` contract as `v4.7.2` and `v5.0.0`.
- Options: `shared`, `fPIC`. Tests and microbenchmarks stay off; `ROARING_BUILD_STATIC` follows `shared`.
- Keep the upstream pkg-config file and rewrite its baked `CMAKE_INSTALL_PREFIX` to relocatable `${pcfiledir}/../..`.
- Metadata is the complete `pkg-config --cflags --libs` lookup.
- `onTest` compiles the Conan `test_package.cpp` consumer with those lookup flags.
