### PR TITLE
feat(primesieve): add LLAR formula

### DIFF
--- a/kimwalisch/primesieve/v12.15/primesieve_llar.gox
+++ b/kimwalisch/primesieve/v12.15/primesieve_llar.gox
@@ -1,0 +1,124 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <primesieve.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+int main() {
+  std::vector<uint64_t> primes;
+  primesieve::generate_n_primes(5, &primes);
+  std::cout << "First 5 primes: ";
+  for (const auto prime : primes) {
+    std::cout << prime << ' ';
+  }
+  std::cout << '\n';
+}
+`
+
+id "kimwalisch/primesieve"
+
+fromVer "v12.15"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+	"with_multiarch": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" && name != "with_multiarch" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := target.options["shared"][0] == "ON"
+	fPIC := target.options["fPIC"][0] == "ON"
+	withMultiarch := target.options["with_multiarch"][0] == "ON"
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.defineBool "BUILD_PRIMESIEVE", false
+	c.defineBool "BUILD_DOC", false
+	c.defineBool "BUILD_EXAMPLES", false
+	c.defineBool "BUILD_TESTS", false
+	c.defineBool "WITH_MULTIARCH", withMultiarch
+	c.defineBool "BUILD_STATIC_LIBS", !shared
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "COPYING"), os.readFile(filepath.join(ctx.SourceDir, "COPYING"))!, 0o644)!
+
+	// CMake writes prefix and GNUInstallDirs paths from CMAKE_INSTALL_PREFIX.
+	// Keep the generated flags and make the installed file relocatable.
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", "primesieve.pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix="+installDir, "prefix=$${pcfiledir}/../..", 1)
+	pc = strings.replace(pc, "bindir="+filepath.join(installDir, "bin"), "bindir=$${prefix}/bin", 1)
+	pc = strings.replace(pc, "libdir="+filepath.join(installDir, "lib"), "libdir=$${prefix}/lib", 1)
+	pc = strings.replace(pc, "includedir="+filepath.join(installDir, "include"), "includedir=$${prefix}/include", 1)
+
+	linux := slices.contains(target.require["os"], "linux")
+	if linux {
+		lines := pc.split("\n")
+		for i, line in lines {
+			if line.hasPrefix("Libs:") {
+				if !strings.contains(line, "-lpthread") {
+					lines[i] += " -lpthread"
+				}
+				if !strings.contains(line, "-lm") {
+					lines[i] += " -lm"
+				}
+				break
+			}
+		}
+		pc = lines.join("\n")
+	}
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("primesieve")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "primesieve.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("primesieve")!), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	exec! "c++", "-std=c++11", consumer, "-o", binary, "@"+flagsFile
+
+	if target.options["shared"][0] == "ON" {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/kimwalisch/primesieve/versions.json
+++ b/kimwalisch/primesieve/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "kimwalisch/primesieve",
+	"deps": {}
+}


### PR DESCRIPTION
Add an idiomatic LLAR formula for `kimwalisch/primesieve` based on the Conan Center recipe and upstream v12.15.

The implementation includes:
- adding `kimwalisch/primesieve/versions.json` and `kimwalisch/primesieve/v12.15/primesieve_llar.gox`
- building the library with the LLAR `cmake` helper while disabling the CLI, docs, examples, and tests
- keeping the upstream-generated `primesieve.pc`, making it relocatable, and publishing metadata from `pkgconfig.lookup("primesieve")`
- installing `COPYING` and validating the package with a C++ consumer that includes `primesieve.hpp`

This keeps the upstream install contract intact for downstream consumers while closing issue #69.

Closes #69
