### PR TITLE
formula: add LibreCAD/libdxfrw

### DIFF
--- a/LibreCAD/libdxfrw/LC2.2.0/libdxfrw_llar.gox
+++ b/LibreCAD/libdxfrw/LC2.2.0/libdxfrw_llar.gox
@@ -1,0 +1,105 @@
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+const consumerSource = `#include <libdxfrw.h>
+
+int main() {
+    dxfRW reader("dummy.dxf");
+    return 0;
+}
+`
+
+id "LibreCAD/libdxfrw"
+
+fromVer "LC2.2.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := target.options["shared"][0] == "ON"
+	fPIC := target.options["fPIC"][0] == "ON"
+
+	cmakeLists := filepath.join(ctx.SourceDir, "CMakeLists.txt")
+	source := string(os.readFile(cmakeLists)!)
+	source = strings.replace(source, "-Werror", "", 1)
+	os.writeFile(cmakeLists, []byte(source), 0o644)!
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.define "CMAKE_INSTALL_LIBDIR", "lib"
+	c.define "CMAKE_POLICY_VERSION_MINIMUM", "3.5"
+	c.defineBool "BUILD_SHARED_LIBS", shared
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "LIBDXFRW_BUILD_DOC", false
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "COPYING"), os.readFile(filepath.join(ctx.SourceDir, "COPYING"))!, 0o644)!
+
+	pcPath := filepath.join(installDir, "lib", "pkgconfig", "libdxfrw.pc")
+	pc := string(os.readFile(pcPath)!)
+	pc = strings.replace(pc, "prefix="+installDir, "prefix=$${pcfiledir}/../..", 1)
+	pc = strings.replace(pc, "exec_prefix="+installDir, "exec_prefix=$${prefix}", 1)
+	pc = strings.replace(pc, "libdir=|"+filepath.join(installDir, "lib"), "libdir=$${prefix}/lib", 1)
+	pc = strings.replace(pc, "libdir="+filepath.join(installDir, "lib"), "libdir=$${prefix}/lib", 1)
+	pc = strings.replace(pc, "includedir="+filepath.join(installDir, "include"), "includedir=$${prefix}/include", 1)
+	if slices.contains(target.require["os"], "linux") {
+		lines := pc.split("\n")
+		for i, line in lines {
+			if line.hasPrefix("Libs:") && !strings.contains(line, " -lm") {
+				lines[i] = line + " -lm"
+			}
+		}
+		pc = strings.join(lines, "\n")
+	}
+	os.writeFile(pcPath, []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("libdxfrw")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "libdxfrw.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("libdxfrw")!), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	exec! "c++", "-std=c++11", consumer, "-o", binary, "@"+flagsFile
+
+	if target.options["shared"][0] == "ON" {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/LibreCAD/libdxfrw/libdxfrw_cmp.gox
+++ b/LibreCAD/libdxfrw/libdxfrw_cmp.gox
@@ -1,0 +1,16 @@
+import "strings"
+
+// Upstream tags mix GNU-incompatible spellings: v0.5.12, 1.0.1, and LC2.2.0.
+// GNU orders v0.5.12 above LC2.2.0, so map LC2.2.0 to 2.2.0, strip an optional
+// v, then compare as semantic versions. Every visible tag is in this domain:
+// 1.0.0, 1.0.1, 1.1.0-rc1, LC2.2.0, v0.5.10, v0.5.12.
+func normalize(version string) string {
+	if version == "LC2.2.0" {
+		version = "2.2.0"
+	}
+	return "v" + strings.trimPrefix(version, "v")
+}
+
+compareVer (a, b) => {
+	return semver.Compare(normalize(a.Version), normalize(b.Version))
+}

--- a/LibreCAD/libdxfrw/versions.json
+++ b/LibreCAD/libdxfrw/versions.json
@@ -1,0 +1,4 @@
+{
+	"path": "LibreCAD/libdxfrw",
+	"deps": {}
+}


### PR DESCRIPTION
Closes issues/40

Adds an LLAR Formula for LibreCAD/libdxfrw from the Conan Center recipe (pin 2.2.0 = tag LC2.2.0).

- Builds with the CMake helper, shared=OFF / fPIC=ON, and LIBDXFRW_BUILD_DOC=false.
- Removes -Werror from CMakeLists.txt via strings.replace.
- Keeps and rewrites the installed libdxfrw.pc to be relocatable; metadata comes from pkgconfig.lookup("libdxfrw").
- Adds a comparator that maps LC2.2.0 -> 2.2.0, strips an optional v, then uses semver.Compare so 2.2.0 wins over GNU-ordered v0.5.12.
- onTest compiles dxfRW reader("dummy.dxf") with c++ -std=c++11 against the complete pkg-config flags.

Validation: `/Users/haolan/go/bin/llar test --verbose ./LibreCAD/libdxfrw --os darwin --arch arm64`