### PR TITLE
formula: add orange-cpp/omath

### DIFF
--- a/orange-cpp/omath/omath_cmp.gox
+++ b/orange-cpp/omath/omath_cmp.gox
@@ -1,0 +1,20 @@
+import "strings"
+
+// omath tags are mostly v-prefixed releases, plus v5-ci-test and v5.1.0.rcN
+// spellings that are not Go semantic versions. Normalize those so every
+// visible tag stays in the comparator domain and GNU cannot prefer
+// v5-ci-test over a real 5.x release.
+func normalize(version string) string {
+	version = strings.trimPrefix(version, "v")
+	if version == "5-ci-test" {
+		return "v4.99.0"
+	}
+	if i := strings.lastIndex(version, ".rc"); i >= 0 {
+		return "v" + version[:i] + "-" + version[i+1:]
+	}
+	return "v" + version
+}
+
+compareVer (a, b) => {
+	return semver.Compare(normalize(a.Version), normalize(b.Version))
+}

--- a/orange-cpp/omath/v5.0.0/omath_llar.gox
+++ b/orange-cpp/omath/v5.0.0/omath_llar.gox
@@ -1,0 +1,101 @@
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const consumerSource = `#include <omath/linear_algebra/vector3.hpp>
+#include <omath/linear_algebra/mat.hpp>
+
+int main() {
+    omath::Vector3<float> v{1.f, 2.f, 3.f};
+    return v.z > 0.f ? 0 : 1;
+}
+`
+
+id "orange-cpp/omath"
+
+fromVer "v5.0.0"
+
+defaults {
+	"shared": "OFF",
+	"fPIC": "ON",
+}
+
+filter => {
+	for name, values in target.options {
+		if name != "shared" && name != "fPIC" {
+			return false
+		}
+		for value in values {
+			if value != "ON" && value != "OFF" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+onBuild ctx => {
+	installDir := ctx.outputDir
+	shared := target.options["shared"][0] == "ON"
+	fPIC := target.options["fPIC"][0] == "ON"
+
+	c := cmake.new(ctx.SourceDir, filepath.join(ctx.SourceDir, "_build"), installDir)
+	c.defineBool "CMAKE_POSITION_INDEPENDENT_CODE", fPIC
+	c.defineBool "OMATH_USE_UNITY_BUILD", false
+	c.defineBool "OMATH_BUILD_TESTS", false
+	c.defineBool "OMATH_THREAT_WARNING_AS_ERROR", false
+	c.defineBool "OMATH_BUILD_BENCHMARK", false
+	c.defineBool "OMATH_BUILD_EXAMPLES", false
+	c.defineBool "OMATH_BUILD_AS_SHARED_LIBRARY", shared
+	c.defineBool "OMATH_BUILD_VIA_VCPKG", false
+	c.configure
+	c.build
+	c.install
+
+	licenseDir := filepath.join(installDir, "licenses")
+	os.mkdirAll(licenseDir, 0o755)!
+	os.writeFile(filepath.join(licenseDir, "LICENSE"), os.readFile(filepath.join(ctx.SourceDir, "LICENSE"))!, 0o644)!
+
+	version := strings.trimSpace(string(os.readFile(filepath.join(ctx.SourceDir, "VERSION"))!))
+	pcDir := filepath.join(installDir, "lib", "pkgconfig")
+	os.mkdirAll(pcDir, 0o755)!
+	pc := `prefix=$${pcfiledir}/../..
+exec_prefix=$${prefix}
+libdir=$${prefix}/lib
+includedir=$${prefix}/include
+
+Name: omath
+Description: Cross-platform modern general purpose math library written in C++23
+Version: ` + version + `
+Libs: -L$${libdir} -lomath
+Cflags: -I$${includedir} -DOMATH_SUPRESS_SAFETY_CHECKS -DOMATH_ENABLE_FORCE_INLINE -DOMATH_ENABLE_LEGACY
+`
+	os.writeFile(filepath.join(pcDir, "omath.pc"), []byte(pc), 0o644)!
+
+	pkgconfig.use installDir
+	ctx.setMetadata pkgconfig.lookup("omath")!
+}
+
+onTest ctx => {
+	installDir := ctx.outputDir
+	testDir := filepath.join(ctx.SourceDir, "_llar_consumer")
+	os.mkdirAll(testDir, 0o755)!
+
+	consumer := filepath.join(testDir, "consumer.cpp")
+	os.writeFile(consumer, []byte(consumerSource), 0o644)!
+
+	pkgconfig.use installDir
+	flagsFile := filepath.join(testDir, "omath.flags")
+	os.writeFile(flagsFile, []byte(pkgconfig.lookup("omath")!), 0o644)!
+
+	binary := filepath.join(testDir, "consumer")
+	exec! "c++", "-std=c++23", consumer, "-o", binary, "@"+flagsFile
+
+	if target.options["shared"][0] == "ON" {
+		os.setenv("LD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+		os.setenv("DYLD_LIBRARY_PATH", filepath.join(installDir, "lib"))!
+	}
+	exec! binary
+}

--- a/orange-cpp/omath/versions.json
+++ b/orange-cpp/omath/versions.json
@@ -1,0 +1,4 @@
+{
+  "path": "orange-cpp/omath",
+  "deps": {}
+}


### PR DESCRIPTION
Add an idiomatic LLAR formula for `orange-cpp/omath` based on the Conan Center recipe.

fromVer is `v5.0.0` (Conan pin 5.0.0 / tag `v5.0.0`). CMake cache flags remain compatible through latest `v5.5.2`.

Closes issues/34